### PR TITLE
Improvements with writing files on UI thread

### DIFF
--- a/WebtrekkSDK/WebtrekkSDK/src/main/java/com/webtrekk/webtrekksdk/Configuration/TrackingConfigurationDownloadTask.java
+++ b/WebtrekkSDK/WebtrekkSDK/src/main/java/com/webtrekk/webtrekksdk/Configuration/TrackingConfigurationDownloadTask.java
@@ -114,7 +114,7 @@ public class TrackingConfigurationDownloadTask extends AsyncTask<String, Void, T
                     // either store it as xml on the internal storage or save it as xml string in the shared prefs
                     WebtrekkLogging.log("saving new trackingConfiguration to preferences");
                     SharedPreferences sharedPrefs = HelperFunctions.getWebTrekkSharedPreference(context);
-                    sharedPrefs.edit().putString(Webtrekk.PREFERENCE_KEY_CONFIGURATION, trackingConfigurationString).commit();
+                    sharedPrefs.edit().putString(Webtrekk.PREFERENCE_KEY_CONFIGURATION, trackingConfigurationString).apply();
 
                     //TODO: update the current configuration only if valid and newer
                     WebtrekkLogging.log("updating current trackingConfiguration");

--- a/WebtrekkSDK/WebtrekkSDK/src/main/java/com/webtrekk/webtrekksdk/Modules/AppinstallGoal.java
+++ b/WebtrekkSDK/WebtrekkSDK/src/main/java/com/webtrekk/webtrekksdk/Modules/AppinstallGoal.java
@@ -36,7 +36,7 @@ public class AppinstallGoal {
     public void initAppinstallGoal(@NonNull Context context){
         if (!isAppinstallGoalProcessed(context)){
             SharedPreferences.Editor editor = getPreferences(context).edit();
-            editor.putBoolean(AppinstallGoal.appinstallGoal, true).commit();
+            editor.putBoolean(AppinstallGoal.appinstallGoal, true).apply();
         }
     }
 
@@ -51,7 +51,7 @@ public class AppinstallGoal {
             SharedPreferences.Editor editor = getPreferences(context).edit();
             editor.remove(AppinstallGoal.appinstallGoal);
             editor.putBoolean(AppinstallGoal.appinstallGoalProcessed, true);
-            editor.commit();
+            editor.apply();
         }
     }
 

--- a/WebtrekkSDK/WebtrekkSDK/src/main/java/com/webtrekk/webtrekksdk/Modules/Campaign.java
+++ b/WebtrekkSDK/WebtrekkSDK/src/main/java/com/webtrekk/webtrekksdk/Modules/Campaign.java
@@ -388,7 +388,7 @@ public class Campaign extends Thread
         if (advertizingID != null)
             editor.putString(ADV_ID, advertizingID);
         editor.putBoolean(OPT_OUT, isOptOut);
-        editor.commit();
+        editor.apply();
     }
 
     /**
@@ -404,7 +404,7 @@ public class Campaign extends Thread
     private void finishProcessCampaign(@NonNull Context context){
         getFirstStartInitiated(context, true);
         SharedPreferences.Editor editor = HelperFunctions.getWebTrekkSharedPreference(context).edit();
-        editor.putBoolean(Campaign.CAMPAIGN_PROCESS_FINISHED, true).commit();
+        editor.putBoolean(Campaign.CAMPAIGN_PROCESS_FINISHED, true).apply();
     }
 
     /**

--- a/WebtrekkSDK/WebtrekkSDK/src/main/java/com/webtrekk/webtrekksdk/Request/RequestFactory.java
+++ b/WebtrekkSDK/WebtrekkSDK/src/main/java/com/webtrekk/webtrekksdk/Request/RequestFactory.java
@@ -137,7 +137,7 @@ public class RequestFactory {
         mIsOptout = isOptout;
 
         SharedPreferences preferences = HelperFunctions.getWebTrekkSharedPreference(mContext);
-        preferences.edit().putBoolean(PREFERENCE_KEY_OPTED_OUT, isOptout).commit();
+        preferences.edit().putBoolean(PREFERENCE_KEY_OPTED_OUT, isOptout).apply();
     }
 
     public boolean isSampling() {
@@ -268,7 +268,7 @@ public class RequestFactory {
         // store the preference keys if the device is sampling and the sampling value
         editor.putBoolean(PREFERENCE_KEY_IS_SAMPLING, mIsSampling);
         editor.putInt(PREFERENCE_KEY_SAMPLING, mTrackingConfiguration.getSampling());
-        editor.commit();
+        editor.apply();
         WebtrekkLogging.log("isSampling = " + mIsSampling + ", samplingRate = " + mTrackingConfiguration.getSampling());
     }
 

--- a/WebtrekkSDK/WebtrekkSDK/src/main/java/com/webtrekk/webtrekksdk/Utils/HelperFunctions.java
+++ b/WebtrekkSDK/WebtrekkSDK/src/main/java/com/webtrekk/webtrekksdk/Utils/HelperFunctions.java
@@ -273,7 +273,7 @@ final public class HelperFunctions {
     public static String getEverId(Context context) {
         SharedPreferences preferences = getWebTrekkSharedPreference(context);
         if (!preferences.contains(Webtrekk.PREFERENCE_KEY_EVER_ID)) {
-            preferences.edit().putString(Webtrekk.PREFERENCE_KEY_EVER_ID, HelperFunctions.generateEverid()).commit();
+            preferences.edit().putString(Webtrekk.PREFERENCE_KEY_EVER_ID, HelperFunctions.generateEverid()).apply();
             // for compatibility reasons put the key here for new installation
             //preferences.edit().putString(Webtrekk.PREFERENCE_KEY_INSTALLATION_FLAG, "1");
         }
@@ -282,14 +282,14 @@ final public class HelperFunctions {
 
     public static void setEverId(Context context, String value) {
         SharedPreferences preferences = getWebTrekkSharedPreference(context);
-        preferences.edit().putString(Webtrekk.PREFERENCE_KEY_EVER_ID, value).commit();
+        preferences.edit().putString(Webtrekk.PREFERENCE_KEY_EVER_ID, value).apply();
     }
 
 
     public static long getAdClearId(Context context) {
         SharedPreferences preferences = HelperFunctions.getWebTrekkSharedPreference(context);
         if (!preferences.contains(AdClearIdUtil.PREFERENCE_KEY_ADCLEAR_ID)) {
-            preferences.edit().putLong(AdClearIdUtil.PREFERENCE_KEY_ADCLEAR_ID, new AdClearIdUtil().generateAdClearId()).commit();
+            preferences.edit().putLong(AdClearIdUtil.PREFERENCE_KEY_ADCLEAR_ID, new AdClearIdUtil().generateAdClearId()).apply();
         }
         return preferences.getLong(AdClearIdUtil.PREFERENCE_KEY_ADCLEAR_ID, 0);
     }
@@ -332,8 +332,7 @@ final public class HelperFunctions {
 
     public static void setAppVersionCode(int versionCode, Context context) {
         SharedPreferences preferences = getWebTrekkSharedPreference(context);
-        ;
-        preferences.edit().putInt(Webtrekk.PREFERENCE_APP_VERSIONCODE, versionCode).commit();
+        preferences.edit().putInt(Webtrekk.PREFERENCE_APP_VERSIONCODE, versionCode).apply();
     }
 
     /**


### PR DESCRIPTION
I enabled extream StrictMode for debug builds and immediately got serious of warnings about disk IO on the main thread.

These changes should fix it.

The method `apply()` was added in [API 9](https://developer.android.com/reference/android/content/SharedPreferences.Editor.html#apply()) but I see that your min SDK is 14.

Please review!