### PR TITLE
Support certificate public key pinning

### DIFF
--- a/webtrekk_sdk/src/main/java/com/webtrekk/webtrekksdk/Modules/Campaign.java
+++ b/webtrekk_sdk/src/main/java/com/webtrekk/webtrekksdk/Modules/Campaign.java
@@ -27,8 +27,8 @@ import android.support.v4.content.LocalBroadcastManager;
 import android.util.JsonReader;
 
 import com.webtrekk.webtrekksdk.ReferrerReceiver;
-import com.webtrekk.webtrekksdk.Request.RequestProcessor;
 import com.webtrekk.webtrekksdk.Request.TrackingRequest;
+import com.webtrekk.webtrekksdk.Request.RequestProcessor;
 import com.webtrekk.webtrekksdk.TrackingParameter;
 import com.webtrekk.webtrekksdk.Utils.HelperFunctions;
 import com.webtrekk.webtrekksdk.Utils.PinConnectionValidator;
@@ -50,7 +50,8 @@ import javax.net.ssl.HttpsURLConnection;
  *
  * @hide
  */
-public class Campaign extends Thread {
+public class Campaign extends Thread
+{
     private final String mTrackID;
     private final boolean mFirstStart;
     private final boolean mIsAutoTrackAdvID;
@@ -84,14 +85,17 @@ public class Campaign extends Thread {
     }
 
     /**
-     * @param context      context
-     * @param trackID      track id
+     * @hide
+     * Starts thread for collecting Campain data
+     * @param context context
+     * @param trackID track id
      * @param isFirstStart if this is first start
      * @return instance of Campain class. you need it to interrupt process if application is closed.
-     * @hide Starts thread for collecting Campain data
      */
-    public static Campaign start(Context context, String trackID, boolean isFirstStart, boolean isAutoTrackAdvID, boolean enableCampaign, PinConnectionValidator validator) {
-        if (trackID == null || trackID.isEmpty()) {
+    public static Campaign start(Context context, String trackID, boolean isFirstStart, boolean isAutoTrackAdvID, boolean enableCampaign, PinConnectionValidator validator)
+    {
+        if (trackID == null || trackID.isEmpty())
+        {
             WebtrekkLogging.log("Track ID is received to Campain server is null. Campain can't be tracked");
             return null;
         }
@@ -101,9 +105,7 @@ public class Campaign extends Thread {
         return service;
     }
 
-    /**
-     * @hide
-     */
+    /** @hide */
     private String getStoredReferrer(Context context) {
         String result = null;
 
@@ -114,11 +116,10 @@ public class Campaign extends Thread {
         return result;
     }
 
-    /**
-     * @hide
-     */
+    /** @hide */
     //Parse refferer and get media code
-    private String getGoogleAnalyticMediaCode(String referrer) {
+    private String getGoogleAnalyticMediaCode(String referrer)
+    {
         String campaign = "";
         String content = "";
         String medium = "";
@@ -152,7 +153,7 @@ public class Campaign extends Thread {
             return null;
 
         String campaignId = "wt_mc%3D" + HelperFunctions.urlEncode(source + "." + medium + "." + content + "." + campaign);
-        if (!term.isEmpty()) {
+        if(!term.isEmpty()) {
             campaignId += ";wt_kw%3D" + HelperFunctions.urlEncode(term);
         }
 
@@ -160,21 +161,22 @@ public class Campaign extends Thread {
 
     }
 
-    /**
-     * @hide
-     */
-    private String getClickID(String referrer) {
+    /** @hide */
+    private String getClickID(String referrer)
+    {
         Pattern pattern = Pattern.compile("(^|&)wt_clickid=([^&#=]*)([#&]|$)");
         Matcher matcher = pattern.matcher(referrer);
 
-        if (matcher.find()) {
+        if (matcher.find())
+        {
             return matcher.group(2);
         } else
             return null;
     }
 
     /**
-     * @hide Main thread
+     * @hide
+     * Main thread
      */
     @Override
     public void run() {
@@ -197,31 +199,31 @@ public class Campaign extends Thread {
                 if (adInfo != null) {
                     advID = client.getId(adInfo);
                     isLimitAdEnabled = client.isLimitAdTrackingEnabled(adInfo);
-                } else {
+                }else {
                     WebtrekkLogging.log("Can't get AdvertisingIdClientRef. Might be Google Play Services or Play Store isn't available.");
                 }
 
                 WebtrekkLogging.log("advertiserId: " + advID);
 
-            } catch (Throwable e) {
+            }catch (Throwable e) {
                 String exceptionType = e.getClass().getSimpleName();
-                if (exceptionType.equals("IOException")) {
+                if (exceptionType.equals("IOException")){
                     // Unrecoverable error connecting to Google Play services (e.g.,
                     // the old version of the service doesn't support getting AdvertisingId).
                     WebtrekkLogging.log("Unrecoverable error connecting to Google Play services", e);
                     // the only way understand that process was interrupted.
                     if (e.getMessage().equals("Interrupted exception"))
                         return;
-                } else if (exceptionType.equals("GooglePlayServicesNotAvailableException")) {
+                } else if (exceptionType.equals("GooglePlayServicesNotAvailableException")){
                     // Google Play services is not available entirely.
                     WebtrekkLogging.log("GooglePlayServicesNotAvailableException", e);
-                } else if (exceptionType.equals("GooglePlayServicesRepairableException")) {
+                } else if (exceptionType.equals("GooglePlayServicesRepairableException")){
                     // maybe will work with another try, recheck
                 }
             }
         }
 
-        if (mEnableCampaign) {
+        if (mEnableCampaign){
             //if this is first start wait for referrer for 30 seconds.
             final long waitForReferrerDelay = 10000;
             long timeToEndListener = System.currentTimeMillis() + waitForReferrerDelay;
@@ -241,19 +243,22 @@ public class Campaign extends Thread {
                         continue;
                     }
                 }
-                WebtrekkLogging.log("Referrer is received and readed:" + referrer);
+                WebtrekkLogging.log("Referrer is received and readed:"+referrer);
             }
             String clickID = null;
             String googleMediaCode = null;
 
             // for non first start referrer is always null
-            if (referrer != null) {
+            if (referrer != null)
+            {
                 // is it referrer from Webtrekk
                 clickID = getClickID(referrer);
 
-                if (clickID != null) {
+                if (clickID != null)
+                {
                     WebtrekkLogging.log("Click ID:" + clickID);
-                } else {
+                }else
+                {
                     googleMediaCode = getGoogleAnalyticMediaCode(referrer);
                     if (googleMediaCode != null) {
                         SaveCodeAndAdID(googleMediaCode, advID, isLimitAdEnabled);
@@ -281,7 +286,7 @@ public class Campaign extends Thread {
                 //delete first start and set flag for finishing campaign processing
                 finishProcessCampaign(mContext);
             }
-        } else {
+        }else{
             SaveCodeAndAdID(null, advID, isLimitAdEnabled);
             campaignNotificationMessage("NoCampaignMode", advID);
             //delete first start and set flag for finishing campaign processing
@@ -293,7 +298,8 @@ public class Campaign extends Thread {
     Request media code with Install request. Provides all infromation in request it can.
     Sends request anyway as userAgent should be present.
      */
-    private String requestMediaCode(String advID, String clickID, String userAgent) {
+    private String requestMediaCode(String advID, String clickID, String userAgent)
+    {
         RequestProcessor requestProcessor = new RequestProcessor(null, mValidator);
 
         final TrackingParameter tp = new TrackingParameter();
@@ -302,7 +308,7 @@ public class Campaign extends Thread {
         tp.add(TrackingParameter.Parameter.INST_TRACK_ID, mTrackID);
 
         if (advID != null && !advID.isEmpty())
-            tp.add(TrackingParameter.Parameter.INST_AD_ID, advID);
+            tp.add(TrackingParameter.Parameter.INST_AD_ID , advID);
 
         if (clickID != null && !clickID.isEmpty())
             tp.add(TrackingParameter.Parameter.INST_CLICK_ID, clickID);
@@ -365,20 +371,21 @@ public class Campaign extends Thread {
                 });
                 sleep(Campaign.CAMPAIGN_ANALYZE_PERIOD);
 
-            } catch (MalformedURLException e) {
+            } catch(MalformedURLException e){
                 WebtrekkLogging.log("Error constructing INSTALL URL:" + e.getMessage());
-            } catch (InterruptedException e) {
+            } catch(InterruptedException e){
                 WebtrekkLogging.log("Interruption exception error");
             }
-        } while (finishTime > System.currentTimeMillis() && mMediaCode == null);
+        }while (finishTime > System.currentTimeMillis() && mMediaCode == null);
 
-        return mMediaCode;
+        return  mMediaCode;
     }
 
     /**
-     * Save all information to settings. So it can be used in future and in case something happened with application.
+     Save all information to settings. So it can be used in future and in case something happened with application.
      */
-    private void SaveCodeAndAdID(String mediaCode, String advertizingID, boolean isOptOut) {
+    private void SaveCodeAndAdID(String mediaCode, String advertizingID, boolean isOptOut)
+    {
         SharedPreferences.Editor editor = HelperFunctions.getWebTrekkSharedPreference(mContext).edit();
 
         WebtrekkLogging.log("Campain data is saved mediaCode:" + mediaCode + " advertizingID:" + advertizingID + " isOptOut:" + isOptOut);
@@ -394,13 +401,14 @@ public class Campaign extends Thread {
     /**
      * save if thread was interrupted just after first start. So we can process referrer one more time after second start
      */
-    private void setFirstStartInitiated() {
+    private void setFirstStartInitiated()
+    {
         SharedPreferences.Editor editor = HelperFunctions.getWebTrekkSharedPreference(mContext).edit();
 
         editor.putLong(FIRST_START_INITIATED_TIME, System.currentTimeMillis()).apply();
     }
 
-    private void finishProcessCampaign(@NonNull Context context) {
+    private void finishProcessCampaign(@NonNull Context context){
         getFirstStartInitiated(context, true);
         SharedPreferences.Editor editor = HelperFunctions.getWebTrekkSharedPreference(context).edit();
         editor.putBoolean(Campaign.CAMPAIGN_PROCESS_FINISHED, true).apply();
@@ -409,11 +417,10 @@ public class Campaign extends Thread {
     /**
      * Check if campaign is processed
      * {@hide}
-     *
      * @param context
      * @return true if campaign processing is finished
      */
-    static public boolean isCampaignProcessingFinished(@NonNull Context context) {
+    static public boolean isCampaignProcessingFinished(@NonNull Context context){
         SharedPreferences preferences = HelperFunctions.getWebTrekkSharedPreference(context);
         return preferences.getBoolean(Campaign.CAMPAIGN_PROCESS_FINISHED, false);
     }
@@ -421,10 +428,10 @@ public class Campaign extends Thread {
     /**
      * {@hide}
      * get if thread was interrupted see {@link #setFirstStartInitiated()} delete flag from settings
-     *
      * @return
      */
-    public static boolean getFirstStartInitiated(@NonNull Context context, boolean deleteFlag) {
+    public static boolean getFirstStartInitiated(@NonNull Context context, boolean deleteFlag)
+    {
         SharedPreferences preferences = HelperFunctions.getWebTrekkSharedPreference(context);
 
         boolean isFirstStartOld = preferences.getBoolean(FIRST_START_INITIATED, false);
@@ -442,38 +449,41 @@ public class Campaign extends Thread {
     /**
      * {@hide}
      * get time of start campaign processing
-     *
      * @return
      */
-    @IntRange(from = 0)
-    public static long getFirstStartInitiatedTime(@NonNull Context context) {
+    @IntRange(from=0)
+    public static long getFirstStartInitiatedTime(@NonNull Context context)
+    {
         SharedPreferences preferences = HelperFunctions.getWebTrekkSharedPreference(context);
 
         return preferences.getLong(FIRST_START_INITIATED_TIME, -1);
     }
 
-    public static String getAdvId(@NonNull Context context) {
+    public static String getAdvId(@NonNull Context context)
+    {
         return getAndRemoveInstallSpecificCode(context, ADV_ID, false);
     }
 
-    public static String getMediaCode(@NonNull Context context) {
+    public static String getMediaCode(@NonNull Context context)
+    {
         return getAndRemoveInstallSpecificCode(context, MEDIA_CODE, true);
     }
 
-    public static boolean getOptOut(@NonNull Context context) {
+    public static boolean getOptOut(@NonNull Context context)
+    {
         SharedPreferences preferences = HelperFunctions.getWebTrekkSharedPreference(context);
         return preferences.getBoolean(OPT_OUT, false);
     }
 
     /**
      * help funtion that get information from setting and optionally remove it
-     *
      * @param context
      * @param key
      * @param remove
      * @return
      */
-    static private String getAndRemoveInstallSpecificCode(@NonNull Context context, @NonNull String key, boolean remove) {
+    static private String getAndRemoveInstallSpecificCode(@NonNull Context context, @NonNull String key, boolean remove)
+    {
         String value;
         SharedPreferences preferences = HelperFunctions.getWebTrekkSharedPreference(context);
         value = preferences.getString(key, null);
@@ -484,12 +494,12 @@ public class Campaign extends Thread {
 
     /**
      * Some test message for test application
-     *
      * @param mediaCode
      * @param advID
      */
-    private void campaignNotificationMessage(String mediaCode, String advID) {
-        try {
+    private void campaignNotificationMessage(String mediaCode, String advID)
+    {
+        try{
             if (!mFirstStart)
                 return;
             Intent intent = new Intent(CAMPAIGN_MEDIA_CODE_DEFINED_MESSAGE);
@@ -497,8 +507,8 @@ public class Campaign extends Thread {
             intent.putExtra(MEDIA_CODE, mediaCode);
             intent.putExtra(ADV_ID, advID);
             LocalBroadcastManager.getInstance(mContext).sendBroadcast(intent);
-        } catch (NoClassDefFoundError e) {
-            WebtrekkLogging.log("Cann't broad cast campain message:" + e.getMessage());
+        }catch (NoClassDefFoundError e){
+            WebtrekkLogging.log("Cann't broad cast campain message:"+e.getMessage());
         }
     }
 
@@ -508,11 +518,11 @@ public class Campaign extends Thread {
             return callMethod("com.google.android.gms.ads.identifier.AdvertisingIdClient", null, "getAdvertisingIdInfo", new Class[]{Context.class}, context);
         }
 
-        String getId(Object info) throws Throwable {
+        String getId(Object info) throws Throwable{
             return callMethod(null, info, "getId", null);
         }
 
-        boolean isLimitAdTrackingEnabled(Object info) throws Throwable {
+        boolean isLimitAdTrackingEnabled(Object info) throws Throwable{
             Boolean result = callMethod(null, info, "isLimitAdTrackingEnabled", null);
             return result == null ? false : result;
         }
@@ -524,9 +534,9 @@ public class Campaign extends Thread {
                 Method method = classObj.getMethod(methodName, argumentsTypes);
 
                 return (T) method.invoke(classInstance, argumentsValues);
-            } catch (InvocationTargetException e) {
+            }catch (InvocationTargetException e) {
                 throw e.getCause();
-            } catch (Exception e) {
+            } catch (Exception e){
                 return null;
             }
         }

--- a/webtrekk_sdk/src/main/java/com/webtrekk/webtrekksdk/Request/RequestFactory.java
+++ b/webtrekk_sdk/src/main/java/com/webtrekk/webtrekksdk/Request/RequestFactory.java
@@ -20,7 +20,6 @@ package com.webtrekk.webtrekksdk.Request;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.os.Handler;
 
 import com.webtrekk.webtrekksdk.Configuration.ActivityConfiguration;
 import com.webtrekk.webtrekksdk.Modules.AppinstallGoal;

--- a/webtrekk_sdk/src/main/java/com/webtrekk/webtrekksdk/Request/RequestFactory.java
+++ b/webtrekk_sdk/src/main/java/com/webtrekk/webtrekksdk/Request/RequestFactory.java
@@ -255,7 +255,7 @@ public class RequestFactory {
      * it can be reset with changing the xml config
      */
     private void initSampling() {
-        SharedPreferences preferences = HelperFunctions.getWebTrekkSharedPreference(mContext);;
+        SharedPreferences preferences = HelperFunctions.getWebTrekkSharedPreference(mContext);
 
         if(preferences.contains(PREFERENCE_KEY_IS_SAMPLING)) {
             // key exists so set sampling value and return

--- a/webtrekk_sdk/src/main/java/com/webtrekk/webtrekksdk/Request/RequestFactory.java
+++ b/webtrekk_sdk/src/main/java/com/webtrekk/webtrekksdk/Request/RequestFactory.java
@@ -20,11 +20,12 @@ package com.webtrekk.webtrekksdk.Request;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.os.Handler;
 
 import com.webtrekk.webtrekksdk.Configuration.ActivityConfiguration;
-import com.webtrekk.webtrekksdk.Configuration.TrackingConfiguration;
 import com.webtrekk.webtrekksdk.Modules.AppinstallGoal;
 import com.webtrekk.webtrekksdk.Modules.Campaign;
+import com.webtrekk.webtrekksdk.Configuration.TrackingConfiguration;
 import com.webtrekk.webtrekksdk.TrackingParameter;
 import com.webtrekk.webtrekksdk.TrackingParameter.Parameter;
 import com.webtrekk.webtrekksdk.Utils.HelperFunctions;
@@ -61,6 +62,7 @@ public class RequestFactory {
     private volatile Campaign mCampaign;
     private final AppinstallGoal mAppinstallGoal = new AppinstallGoal();
     TrackingRequestTemporaryStore mPendingRequestStore;
+    private PinConnectionValidator mValidator;
     private static final long PENDING_INTERVAL = 30000;
 
     //additional customer params, this is a globally available HashMap
@@ -92,7 +94,6 @@ public class RequestFactory {
     private TrackingParameter mConstGlobalTrackingParameter;
 
     private RequestUrlStore mRequestUrlStore;
-    private PinConnectionValidator mValidator;
     private String mCustomPageName;
 
     private ScheduledExecutorService mURLSendTimerService;
@@ -105,11 +106,12 @@ public class RequestFactory {
     private ScheduledFuture<?> mFlashTimerFuture;
 
 
-    public void init(Context context, TrackingConfiguration trackingConfiguration, Webtrekk wt, Set<String> validPins) {
+    public void init(Context context, TrackingConfiguration trackingConfiguration, Webtrekk wt, Set<String> validPins)
+    {
         mContext = context;
         mTrackingConfiguration = trackingConfiguration;
 
-        if (mCustomParameter == null) {
+        if(mCustomParameter == null) {
             mCustomParameter = new HashMap<>();
         }
 
@@ -220,19 +222,20 @@ public class RequestFactory {
     }
 
     private void initInternalParameter(boolean isFirstStart) {
-        if (mInternalParameter == null) {
+        if(mInternalParameter == null) {
             mInternalParameter = new TrackingParameter();
         }
         forceNewSession();
         // if the app is started for the first time, the param "one" is 1 otherwise its always 0
-        if (isFirstStart) {
+        if(isFirstStart) {
             mInternalParameter.add(Parameter.APP_FIRST_START, "1");
         } else {
             mInternalParameter.add(Parameter.APP_FIRST_START, "0");
         }
     }
 
-    public void forceNewSession() {
+    public void forceNewSession()
+    {
         // first initalization of the webtrekk instance, so set fns to 1
         mInternalParameter.add(Parameter.FORCE_NEW_SESSION, "1");
     }
@@ -252,20 +255,20 @@ public class RequestFactory {
      * it can be reset with changing the xml config
      */
     private void initSampling() {
-        SharedPreferences preferences = HelperFunctions.getWebTrekkSharedPreference(mContext);
+        SharedPreferences preferences = HelperFunctions.getWebTrekkSharedPreference(mContext);;
 
-        if (preferences.contains(PREFERENCE_KEY_IS_SAMPLING)) {
+        if(preferences.contains(PREFERENCE_KEY_IS_SAMPLING)) {
             // key exists so set sampling value and return
             mIsSampling = preferences.getBoolean(PREFERENCE_KEY_IS_SAMPLING, false);
             // check if the sampling value is unchanged, if so return
-            if (preferences.getInt(PREFERENCE_KEY_SAMPLING, -1) == mTrackingConfiguration.getSampling()) {
+            if(preferences.getInt(PREFERENCE_KEY_SAMPLING, -1) == mTrackingConfiguration.getSampling()) {
                 return;
             }
         }
         // from here on they sampling either changed or is missing, so reinitialize it
         SharedPreferences.Editor editor = preferences.edit();
         // calculate if the device is sampling
-        if (mTrackingConfiguration.getSampling() > 1) {
+        if(mTrackingConfiguration.getSampling()>1) {
             mIsSampling = (Long.valueOf(HelperFunctions.getEverId(mContext)) % mTrackingConfiguration.getSampling()) != 0;
         } else {
             mIsSampling = false;
@@ -285,7 +288,7 @@ public class RequestFactory {
      */
     private void initWebtrekkParameter() {
         // collect all static device information which remain the same for all requests
-        if (mWebtrekkParameter == null) {
+        if(mWebtrekkParameter == null) {
             mWebtrekkParameter = new HashMap<>();
         }
 
@@ -313,29 +316,29 @@ public class RequestFactory {
      * the customer can also add new ones, unknown entries will be ignored by the server
      */
     public void initAutoCustomParameter() {
-        if (mAutoCustomParameter == null) {
+        if(mAutoCustomParameter == null) {
             mAutoCustomParameter = new HashMap<>();
         }
 
-        if (mCustomParameter == null) {
+        if(mCustomParameter == null) {
             mCustomParameter = new HashMap<>();
         }
 
-        if (mTrackingConfiguration.isAutoTrackAppVersionName()) {
+        if(mTrackingConfiguration.isAutoTrackAppVersionName()) {
             mAutoCustomParameter.put("appVersion", HelperFunctions.getAppVersionName(mContext));
         }
 
-        if (mTrackingConfiguration.isAutoTrackAppVersionCode()) {
+        if(mTrackingConfiguration.isAutoTrackAppVersionCode()) {
             mAutoCustomParameter.put("appVersionCode", String.valueOf(HelperFunctions.getAppVersionCode(mContext)));
         }
 
-        if (mTrackingConfiguration.isAutoTrackPlaystoreUsername()) {
+        if(mTrackingConfiguration.isAutoTrackPlaystoreUsername()) {
             Map<String, String> playstoreprofile = HelperFunctions.getUserProfile(mContext);
             mAutoCustomParameter.put("playstoreFamilyname", playstoreprofile.get("sname"));
             mAutoCustomParameter.put("playstoreGivenname", playstoreprofile.get("gname"));
         }
 
-        if (mTrackingConfiguration.isAutoTrackPlaystoreMail()) {
+        if(mTrackingConfiguration.isAutoTrackPlaystoreMail()) {
             //Map<String, String> playstoreprofile = HelperFunctions.getUserProfile(mContext);
             //customParameter.put("playstoreMail", playstoreprofile.get("email"));
             mAutoCustomParameter.put("playstoreMail", HelperFunctions.getMailByAccountManager(mContext));
@@ -345,27 +348,27 @@ public class RequestFactory {
             mAutoCustomParameter.put("appPreinstalled", String.valueOf(HelperFunctions.isAppPreinstalled(mContext)));
         }
 
-        if (mTrackingConfiguration.isAutoTrackAdClearId()) {
+        if(mTrackingConfiguration.isAutoTrackAdClearId()) {
             mAutoCustomParameter.put("adClearId", String.valueOf(HelperFunctions.getAdClearId(mContext)));
         }
 
         // if the app was updated, send out the update request once
 
-        if (mTrackingConfiguration.isAutoTrackAppUpdate()) {
+        if(mTrackingConfiguration.isAutoTrackAppUpdate()) {
             int currentVersion = HelperFunctions.getAppVersionCode(mContext);
             // store the app version code to check for updates
-            if (HelperFunctions.firstStart(mContext)) {
+            if(HelperFunctions.firstStart(mContext)) {
                 HelperFunctions.setAppVersionCode(currentVersion, mContext);
             }
 
-            if (HelperFunctions.updated(mContext, currentVersion)) {
+            if(HelperFunctions.updated(mContext, currentVersion)) {
                 mAutoCustomParameter.put("appUpdated", "1");
-            } else {
+            } else  {
                 mAutoCustomParameter.put("appUpdated", "0");
             }
 
         }
-        if (mTrackingConfiguration.isAutoTrackApiLevel()) {
+        if(mTrackingConfiguration.isAutoTrackApiLevel()) {
             mAutoCustomParameter.put("apiLevel", HelperFunctions.getAPILevel());
 
         }
@@ -374,16 +377,15 @@ public class RequestFactory {
 
     /**
      * this method updates the webtrekk and customer parameter which change with every request
-     *
      * @return
      */
     public void updateDynamicParameter() {
         // put the screen orientation to into the custom parameter, will change with every request
-        if (mAutoCustomParameter != null) {
+        if(mAutoCustomParameter != null) {
             mAutoCustomParameter.put("screenOrientation", HelperFunctions.getOrientation(mContext));
             mAutoCustomParameter.put("connectionType", HelperFunctions.getConnectionString(mContext));
 
-            if (mTrackingConfiguration.isAutoTrackAdvertiserId() && !mAutoCustomParameter.containsKey("advertiserId")
+            if(mTrackingConfiguration.isAutoTrackAdvertiserId() && !mAutoCustomParameter.containsKey("advertiserId")
                     && Campaign.getAdvId(mContext) != null) {
                 mAutoCustomParameter.put("advertiserId", Campaign.getAdvId(mContext));
 
@@ -392,12 +394,12 @@ public class RequestFactory {
             }
 
 
-            if (mRequestUrlStore != null && mTrackingConfiguration.isAutoTrackRequestUrlStoreSize()) {
+            if(mRequestUrlStore != null && mTrackingConfiguration.isAutoTrackRequestUrlStoreSize()) {
                 mAutoCustomParameter.put("requestUrlStoreSize", String.valueOf(mRequestUrlStore.size()));
             }
         }
 
-        if (mWebtrekkParameter != null) {
+        if(mWebtrekkParameter != null) {
             // also update the webtrekk parameter
             mWebtrekkParameter.put(Parameter.SCREEN_RESOLUTION, HelperFunctions.getResolution(mContext));
         }
@@ -406,9 +408,10 @@ public class RequestFactory {
     /*
     Process campaignData
      */
-    private void processInstallGoals(TrackingRequest request) {
+    private void processInstallGoals(TrackingRequest request)
+    {
 
-        if (mAppinstallGoal.isAppinstallGoal(mContext)) {
+        if (mAppinstallGoal.isAppinstallGoal(mContext)){
             request.mTrackingParameter.add(Parameter.ECOM, "900", "1");
             mAppinstallGoal.finishAppinstallGoal(mContext);
         }
@@ -426,7 +429,8 @@ public class RequestFactory {
         }
     }
 
-    public void onFirstStart() {
+    public void onFirstStart()
+    {
         restore();
         //restart referrer getting if applicaiton was paused and resumed back
         if (Campaign.getFirstStartInitiated(mContext, false) && (mCampaign == null || (mCampaign != null && !mCampaign.isAlive()))) {
@@ -434,20 +438,23 @@ public class RequestFactory {
         }
     }
 
-    public void stop() {
+    public void stop()
+    {
         flush();
         if (mCampaign != null && mCampaign.isAlive() && !mCampaign.isInterrupted()) {
             mCampaign.interrupt();
         }
     }
 
-    public void restore() {
+    public void restore()
+    {
         mRequestUrlStore.reset();
         // remove the old backupfile after the requests are loaded into memory/requestUrlStore
         //mRequestUrlStore.deleteRequestsFile();
     }
 
-    public void flush() {
+    public void flush()
+    {
         stopSendURLProcess();
         mRequestUrlStore.flush();
     }
@@ -470,7 +477,7 @@ public class RequestFactory {
         trackingParameter.add(mInternalParameter);
 
         // action params are a special case, no other params but the ones given as parameter in the code
-        if (tp.containsKey(Parameter.ACTION_NAME)) {
+        if(tp.containsKey(Parameter.ACTION_NAME)) {
             applyActivityConfiguration(trackingParameter, true);
             overrideCustomPageName(trackingParameter);
             trackingParameter.add(Parameter.SCREEN_RESOLUTION, mWebtrekkParameter.get(Parameter.SCREEN_RESOLUTION));
@@ -482,7 +489,7 @@ public class RequestFactory {
             trackingParameter.add(Parameter.DEV_LANG, mWebtrekkParameter.get(Parameter.DEV_LANG));
 
             // Also add the auto parameters that are defined to be send with action requests
-            if (mAutoCustomParameter != null) {
+            if(mAutoCustomParameter!= null) {
                 trackingParameter.add(mTrackingConfiguration.getAutoTrackedParameters(mAutoCustomParameter, true));
             }
 
@@ -496,34 +503,34 @@ public class RequestFactory {
         trackingParameter.add(mWebtrekkParameter);
 
         // add the autotracked custom params to the custom params
-        if (mCustomParameter != null) {
+        if(mCustomParameter!= null) {
             mCustomParameter.putAll(mAutoCustomParameter);
         }
 
 
         // first add the globally configured trackingparams which are defined in the webtrekk.globalTrackingParameter, if there are any
-        if (mConstGlobalTrackingParameter != null) {
+        if(mConstGlobalTrackingParameter != null) {
             trackingParameter.add(mConstGlobalTrackingParameter);
         }
 
         // apply autotracking parameters
-        if (mAutoCustomParameter != null) {
+        if(mAutoCustomParameter!= null) {
             trackingParameter.add(mTrackingConfiguration.getAutoTrackedParameters(mAutoCustomParameter, false));
         }
 
         //now map the string values from the code tracking parameters to the custom values defined by webtrekk or the customer
-        if (mCustomParameter != null && mGlobalTrackingParameter != null) {
+        if(mCustomParameter!= null && mGlobalTrackingParameter != null) {
             // first map the global tracking parameter
             TrackingParameter mappedTrackingParameter = mGlobalTrackingParameter.applyMapping(mCustomParameter);
             trackingParameter.add(mappedTrackingParameter);
         }
 
         // second add the globally configured const trackingparams from the xml which may override the ones above
-        if (mTrackingConfiguration.getConstGlobalTrackingParameter() != null) {
+        if(mTrackingConfiguration.getConstGlobalTrackingParameter() != null) {
             trackingParameter.add(mTrackingConfiguration.getConstGlobalTrackingParameter());
         }
         // also add the globally configured mapped trackingparams from the xml which may override the ones above
-        if (mTrackingConfiguration.getGlobalTrackingParameter() != null) {
+        if(mTrackingConfiguration.getGlobalTrackingParameter() != null) {
             TrackingParameter mappedTrackingParameter = mTrackingConfiguration.getGlobalTrackingParameter().applyMapping(mCustomParameter);
             trackingParameter.add(mappedTrackingParameter);
         }
@@ -539,30 +546,32 @@ public class RequestFactory {
 
     }
 
-    private void applyActivityConfiguration(TrackingParameter trackingParameter, boolean onlyNameApply) {
-        if (mTrackingConfiguration.getActivityConfigurations() != null && mTrackingConfiguration.getActivityConfigurations().containsKey(mCurrentActivityName)) {
+    private void applyActivityConfiguration(TrackingParameter trackingParameter, boolean onlyNameApply)
+    {
+        if(mTrackingConfiguration.getActivityConfigurations()!= null && mTrackingConfiguration.getActivityConfigurations().containsKey(mCurrentActivityName)){
             ActivityConfiguration activityConfiguration = mTrackingConfiguration.getActivityConfigurations().get(mCurrentActivityName);
-            if (activityConfiguration != null) {
-                if (activityConfiguration.getConstActivityTrackingParameter() != null && !onlyNameApply) {
+            if(activityConfiguration != null) {
+                if(activityConfiguration.getConstActivityTrackingParameter() != null && !onlyNameApply) {
                     trackingParameter.add(activityConfiguration.getConstActivityTrackingParameter());
                 }
                 TrackingParameter mappedTrackingParameter = activityConfiguration.getActivityTrackingParameter();
-                if (mappedTrackingParameter != null && !onlyNameApply) {
+                if( mappedTrackingParameter != null && !onlyNameApply) {
                     //now map the string values from the xml/code tracking parameters to the custom values defined by webtrekk or the customer
-                    if (mCustomParameter != null) {
+                    if(mCustomParameter!= null) {
                         // first map the global tracking parameter
                         trackingParameter.add(mappedTrackingParameter.applyMapping(mCustomParameter));
                     }
                 }
                 // override the activityname if a mapping name is given
-                if (activityConfiguration.getMappingName() != null) {
+                if(activityConfiguration.getMappingName() != null) {
                     trackingParameter.add(Parameter.ACTIVITY_NAME, activityConfiguration.getMappingName());
                 }
             }
         }
     }
 
-    private void overrideCustomPageName(TrackingParameter trackingParameter) {
+    private void overrideCustomPageName(TrackingParameter trackingParameter)
+    {
         if (mCustomPageName != null)
             trackingParameter.add(Parameter.ACTIVITY_NAME, mCustomPageName);
     }
@@ -573,12 +582,12 @@ public class RequestFactory {
      *
      * @param request the Tracking Request
      */
-    public void addRequest(TrackingRequest request) {
+    public void addRequest(TrackingRequest request)  {
 
-        if (!isCampaignFinished()) {
+        if (!isCampaignFinished()){
             mPendingRequestStore.saveTrackingRequest(request);
         } else {
-            if (!sendPendingRequests()) {
+            if (!sendPendingRequests()){
                 processInstallGoals(request);
             }
             addURL(request.getUrlString());
@@ -591,27 +600,27 @@ public class RequestFactory {
         mAutoCustomParameter.put("appUpdated", "0");
     }
 
-    void addURL(String url) {
+    void addURL(String url){
         // only track if not opted out
-        if (!mIsOptout && !mIsSampling) {
+        if(!mIsOptout && !mIsSampling) {
             WebtrekkLogging.log("adding url: " + url);
             mRequestUrlStore.addURL(url);
         }
     }
 
     //return true if requests was added to queue
-    boolean sendPendingRequests() {
+    boolean sendPendingRequests(){
         boolean result = false;
-        if (isCampaignFinished() && !mPendingRequestStore.queueIsEmpty()) {
+        if (isCampaignFinished() && !mPendingRequestStore.queueIsEmpty()){
             WebtrekkLogging.log("sending pending requests");
             List<TrackingRequest> requests = mPendingRequestStore.getAllSavedRequests();
 
-            if (!requests.isEmpty()) {
+            if (!requests.isEmpty()){
                 processInstallGoals(requests.get(0));
                 result = true;
             }
 
-            for (TrackingRequest request : requests) {
+            for (TrackingRequest request:requests){
                 addURL(request.getUrlString());
             }
             mPendingRequestStore.deleteQueue();
@@ -619,17 +628,17 @@ public class RequestFactory {
         return result;
     }
 
-    private boolean isCampaignFinished() {
+    private boolean isCampaignFinished(){
         return Campaign.isCampaignProcessingFinished(mContext);
     }
 
     /**
      * Start thread for advertazing campaign and getting adv ID.
      * After thread is finished make link to object null for GC
-     *
      * @param isFirstStart
      */
-    public void startAdvertizingThread(boolean isFirstStart) {
+    public void startAdvertizingThread(boolean isFirstStart)
+    {
         if (!mIsOptout) {
             mCampaign = Campaign.start(mContext, mTrackingConfiguration.getTrackId(), isFirstStart,
                     mTrackingConfiguration.isAutoTrackAdvertiserId(), mTrackingConfiguration.isEnableCampaignTracking(), mValidator);
@@ -673,13 +682,12 @@ public class RequestFactory {
     /**
      * this method gets called whenever the send delay is over, it executes the requesthandler in a
      * new thread
-     *
      * @return true if send is done and false if previous send is still in progress or there is no message to send
      */
     public boolean onSendIntervalOver() {
         //WebtrekkLogging.log("onSendIntervalOver: request urls: " + mRequestUrlStore.size()
         //+ " thread done:"+(mRequestProcessorFuture == null ? "null": mRequestProcessorFuture.isDone()));
-        if (mRequestUrlStore.size() > 0 && (mRequestProcessorFuture == null || mRequestProcessorFuture.isDone())) {
+        if(mRequestUrlStore.size() > 0  && (mRequestProcessorFuture == null || mRequestProcessorFuture.isDone())) {
             if (mExecutorService == null) {
                 // use daemon thread.
                 mExecutorService = Executors.newSingleThreadExecutor(new ThreadFactory() {
@@ -694,18 +702,20 @@ public class RequestFactory {
             }
             mRequestProcessorFuture = mExecutorService.submit(new RequestProcessor(mRequestUrlStore, mValidator));
             return true;
-        } else
+        }else
             return false;
     }
 
-    private void flashByTimeout() {
+    private void flashByTimeout()
+    {
         if (mFlashTimerFuture == null)
             return;
         if ((System.currentTimeMillis() - mLastTrackTime) > 60000 && (mRequestProcessorFuture == null || mRequestProcessorFuture.isDone()))
             flush();
     }
 
-    public void stopSendURLProcess() {
+    public void stopSendURLProcess()
+    {
         if (mRequestProcessorFuture != null && !mRequestProcessorFuture.isDone()) {
             mRequestProcessorFuture.cancel(true);
             mExecutorService.shutdownNow();
@@ -713,7 +723,7 @@ public class RequestFactory {
                 // waiting for 4 seconds to avoid ANR
                 WebtrekkLogging.log("Start waiting for send URL thread to stop");
                 boolean isTerminated = mExecutorService.awaitTermination(4, TimeUnit.SECONDS);
-                WebtrekkLogging.log("Stop to wait for send URL thread. Process stopped result is:" + isTerminated);
+                WebtrekkLogging.log("Stop to wait for send URL thread. Process stopped result is:"+isTerminated);
             } catch (InterruptedException e) {
                 WebtrekkLogging.log("Can't terminate sending process");
             }

--- a/webtrekk_sdk/src/main/java/com/webtrekk/webtrekksdk/Request/RequestFactory.java
+++ b/webtrekk_sdk/src/main/java/com/webtrekk/webtrekksdk/Request/RequestFactory.java
@@ -253,7 +253,6 @@ public class RequestFactory {
      */
     private void initSampling() {
         SharedPreferences preferences = HelperFunctions.getWebTrekkSharedPreference(mContext);
-        ;
 
         if (preferences.contains(PREFERENCE_KEY_IS_SAMPLING)) {
             // key exists so set sampling value and return

--- a/webtrekk_sdk/src/main/java/com/webtrekk/webtrekksdk/Request/RequestProcessor.java
+++ b/webtrekk_sdk/src/main/java/com/webtrekk/webtrekksdk/Request/RequestProcessor.java
@@ -18,37 +18,39 @@
 
 package com.webtrekk.webtrekksdk.Request;
 
-import com.webtrekk.webtrekksdk.Request.RequestUrlStore;
+import com.webtrekk.webtrekksdk.Utils.PinConnectionValidator;
 import com.webtrekk.webtrekksdk.Utils.WebtrekkLogging;
 
 import java.io.EOFException;
 import java.io.IOException;
-import java.io.InterruptedIOException;
-import java.net.HttpURLConnection;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.net.URL;
 import java.net.UnknownHostException;
 
+import javax.net.ssl.HttpsURLConnection;
+
 /**
  * this class sends the requests to the server
  * it handles just the networking tasks
+ *
  * @hide
  */
 public class RequestProcessor implements Runnable {
 
     public static final int NETWORK_CONNECTION_TIMEOUT = 60 * 1000;  // 1 minute
-    static final int NETWORK_READ_TIMEOUT = 60 * 1000;  // 1 minute
+    private static final int NETWORK_READ_TIMEOUT = 60 * 1000;  // 1 minute
 
     private final RequestUrlStore mRequestUrlStore;
+    private final PinConnectionValidator mValidator;
 
-    public interface ProcessOutputCallback
-    {
-        public void process(int statusCode, HttpURLConnection connection);
+    public interface ProcessOutputCallback {
+        void process(int statusCode, HttpsURLConnection connection);
     }
 
-    public RequestProcessor(RequestUrlStore requestUrlStore) {
+    public RequestProcessor(RequestUrlStore requestUrlStore, PinConnectionValidator validator) {
         mRequestUrlStore = requestUrlStore;
+        mValidator = validator;
     }
 
     /**
@@ -73,8 +75,8 @@ public class RequestProcessor implements Runnable {
      * @throws IOException
      */
 
-    public HttpURLConnection getUrlConnection(URL url) throws IOException {
-        return (HttpURLConnection) url.openConnection();
+    public HttpsURLConnection getUrlConnection(URL url) throws IOException {
+        return (HttpsURLConnection) url.openConnection();
     }
 
     /**
@@ -84,7 +86,7 @@ public class RequestProcessor implements Runnable {
      * @return statusCode, 0 for retry, -1 for remove, 200 for success
      */
     public int sendRequest(URL url, ProcessOutputCallback processOutput) throws InterruptedException {
-        HttpURLConnection connection = null;
+        HttpsURLConnection connection = null;
         try {
             connection = getUrlConnection(url);
 
@@ -96,6 +98,7 @@ public class RequestProcessor implements Runnable {
             connection.setReadTimeout(NETWORK_READ_TIMEOUT);
             connection.setUseCaches(false);
             connection.connect();
+            mValidator.validatePinning(connection);
             int statusCode = connection.getResponseCode();
 
             if (processOutput != null)
@@ -112,7 +115,7 @@ public class RequestProcessor implements Runnable {
         } catch (SocketException e) {
             WebtrekkLogging.log("RequestProcessor: Socket Exception.", e);
             return 500;
-        }  catch (UnknownHostException e) {
+        } catch (UnknownHostException e) {
             WebtrekkLogging.log("RequestProcessor: UnknownHost > Will retry later.", e);
             return 500;
         } catch (IOException e) {
@@ -161,7 +164,7 @@ public class RequestProcessor implements Runnable {
                 } else if (statusCode >= 500 && statusCode < 600) {
                     //try to send later
                     break;
-                } else{ //400-499 case
+                } else { //400-499 case
                     WebtrekkLogging.log("removing URL from queue as status code is between 400 and 499 or unexpected.");
                     mRequestUrlStore.removeLastURL();
                 }

--- a/webtrekk_sdk/src/main/java/com/webtrekk/webtrekksdk/Utils/PinConnectionValidator.java
+++ b/webtrekk_sdk/src/main/java/com/webtrekk/webtrekksdk/Utils/PinConnectionValidator.java
@@ -1,0 +1,146 @@
+package com.webtrekk.webtrekksdk.Utils;
+
+import android.net.http.X509TrustManagerExtensions;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.util.Base64;
+import android.util.Log;
+
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+
+public class PinConnectionValidator {
+
+    @NonNull
+    private final Set<String> validPins;
+
+    public PinConnectionValidator(@NonNull Set<String> validPins) {
+        this.validPins = validPins;
+    }
+
+    private TrustChecker trustChecker = getTrustChecker();
+
+    public void validatePinning(@NonNull HttpsURLConnection conn) throws SSLException {
+
+        // Don't validate if no valid pins are provided
+        if (validPins.isEmpty()) return;
+
+        StringBuilder certChainMsg = new StringBuilder();
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            List<X509Certificate> trustedChain = trustedChain(conn);
+            for (Certificate cert : trustedChain) {
+                byte[] publicKey = cert.getPublicKey().getEncoded();
+                md.update(publicKey, 0, publicKey.length);
+                String pin = Base64.encodeToString(md.digest(), Base64.NO_WRAP);
+                certChainMsg.append("    sha256/")
+                        .append(pin).append(" : ")
+                        .append(cert.getPublicKey().toString())
+                        .append("\n");
+                if (validPins.contains(pin)) {
+                    return;
+                }
+            }
+        } catch (NoSuchAlgorithmException e) {
+            throw new SSLException(e);
+        }
+        throw new SSLPeerUnverifiedException("Certificate pinning " +
+                "failure\n  Peer certificate chain:\n" + certChainMsg);
+    }
+
+    @NonNull
+    private List<X509Certificate> trustedChain(@NonNull HttpsURLConnection conn)
+            throws SSLException {
+
+        Certificate[] serverCerts = conn.getServerCertificates();
+        X509Certificate[] untrustedCerts = Arrays.copyOf(serverCerts, serverCerts.length,
+                X509Certificate[].class);
+        String host = conn.getURL().getHost();
+
+        try {
+            return trustChecker.checkServerTrusted(untrustedCerts, "RSA", host);
+        } catch (CertificateException e) {
+            throw new SSLException(e);
+        }
+    }
+
+    @NonNull
+    private TrustChecker getTrustChecker() {
+        final X509TrustManager finalX509TrustManager = findTrustManager();
+
+        if (finalX509TrustManager != null &&
+                android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            return new TrustChecker() {
+
+                X509TrustManagerExtensions extensions = new X509TrustManagerExtensions(finalX509TrustManager);
+
+                @Override
+                public List<X509Certificate> checkServerTrusted(
+                        X509Certificate[] chain, String authType, String host)
+                        throws CertificateException {
+                    return extensions.checkServerTrusted(chain, authType, host);
+                }
+            };
+        }
+
+        // Implement for other versions
+        return new TrustChecker() {
+            @Override
+            public List<X509Certificate> checkServerTrusted(
+                    X509Certificate[] chain, String authType, String host) throws CertificateException {
+                throw new CertificateException("No valid certificate checker");
+            }
+        };
+    }
+
+    @Nullable
+    private X509TrustManager findTrustManager() {
+        TrustManagerFactory trustManagerFactory = null;
+        try {
+            trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory
+                    .getDefaultAlgorithm());
+            trustManagerFactory.init((KeyStore) null);
+        } catch (NoSuchAlgorithmException e) {
+            Log.e("Trust", e.getMessage(), e);
+        } catch (KeyStoreException e) {
+            Log.e("Trust", e.getMessage(), e);
+        }
+
+        if (trustManagerFactory != null) {
+            // Find first X509TrustManager in the TrustManagerFactory
+            X509TrustManager x509TrustManager = null;
+            for (TrustManager trustManager : trustManagerFactory.getTrustManagers()) {
+                if (trustManager instanceof X509TrustManager) {
+                    x509TrustManager = (X509TrustManager) trustManager;
+                    break;
+                }
+            }
+            return x509TrustManager;
+        }
+
+        return null;
+    }
+
+    interface TrustChecker {
+        List<X509Certificate> checkServerTrusted(
+                X509Certificate[] chain,
+                String authType,
+                String host
+        ) throws CertificateException;
+    }
+}

--- a/webtrekk_sdk/src/main/java/com/webtrekk/webtrekksdk/Utils/PinConnectionValidator.java
+++ b/webtrekk_sdk/src/main/java/com/webtrekk/webtrekksdk/Utils/PinConnectionValidator.java
@@ -26,10 +26,10 @@ import javax.net.ssl.X509TrustManager;
 
 public class PinConnectionValidator {
 
-    @NonNull
+    @Nullable
     private final Set<String> validPins;
 
-    public PinConnectionValidator(@NonNull Set<String> validPins) {
+    public PinConnectionValidator(@Nullable Set<String> validPins) {
         this.validPins = validPins;
     }
 
@@ -38,7 +38,7 @@ public class PinConnectionValidator {
     public void validatePinning(@NonNull HttpsURLConnection conn) throws SSLException {
 
         // Don't validate if no valid pins are provided
-        if (validPins.isEmpty()) {
+        if (validPins == null || validPins.isEmpty()) {
             WebtrekkLogging.log("PinConnectionValidator: Warning - No public pins provided. Pinning will be ignored.");
             return;
         }

--- a/webtrekk_sdk/src/main/java/com/webtrekk/webtrekksdk/Utils/PinConnectionValidator.java
+++ b/webtrekk_sdk/src/main/java/com/webtrekk/webtrekksdk/Utils/PinConnectionValidator.java
@@ -38,7 +38,10 @@ public class PinConnectionValidator {
     public void validatePinning(@NonNull HttpsURLConnection conn) throws SSLException {
 
         // Don't validate if no valid pins are provided
-        if (validPins.isEmpty()) return;
+        if (validPins.isEmpty()) {
+            WebtrekkLogging.log("PinConnectionValidator: Warning - No public pins provided. Pinning will be ignored.");
+            return;
+        }
 
         StringBuilder certChainMsg = new StringBuilder();
         try {

--- a/webtrekk_sdk/src/main/java/com/webtrekk/webtrekksdk/Webtrekk.java
+++ b/webtrekk_sdk/src/main/java/com/webtrekk/webtrekksdk/Webtrekk.java
@@ -122,15 +122,25 @@ public class Webtrekk implements ActivityListener.Callback {
      * application starts, for example in the Application Class or the Main Activitys onCreate.
      * @param app application instance
      * @param configResourceID id of config resource
-     *
      */
     final public void initWebtrekk(final Application app, int configResourceID) {
+        initWebtrekk(app, configResourceID, null);
+    }
+
+    /**
+     * this initializes the webtrekk tracking configuration, it has to be called only once when the
+     * application starts, for example in the Application Class or the Main Activitys onCreate.
+     * @param app application instance
+     * @param configResourceID id of config resource
+     * @param validPins SHA-256 pins
+     */
+    final public void initWebtrekk(final Application app, int configResourceID, Set<String> validPins) {
         if (app == null) {
             throw new IllegalArgumentException("no valid app");
         }
         initVersions(app.getApplicationContext());
         initAutoTracking(app);
-        initWebtrekk(app.getApplicationContext(), configResourceID, null);
+        initWebtrekk(app.getApplicationContext(), configResourceID, validPins);
     }
 
     /**
@@ -152,7 +162,7 @@ public class Webtrekk implements ActivityListener.Callback {
      * @param c the application mContext / mContext of the main activity
      * @param configResourceID resource config ID.
      */
-    final public void initWebtrekk(final Context c, int configResourceID, Set<String> validPins) {
+    private void initWebtrekk(final Context c, int configResourceID, Set<String> validPins) {
         if (c == null) {
             throw new IllegalArgumentException("no valid mContext");
         }

--- a/webtrekk_sdk/src/main/java/com/webtrekk/webtrekksdk/Webtrekk.java
+++ b/webtrekk_sdk/src/main/java/com/webtrekk/webtrekksdk/Webtrekk.java
@@ -43,7 +43,6 @@ import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -108,6 +107,18 @@ public class Webtrekk implements ActivityListener.Callback {
         initWebtrekk(app, R.raw.webtrekk_config);
     }
 
+
+    /**
+     * this initializes the webtrekk tracking configuration, it has to be called only once when the
+     * application starts, for example in the Application Class or the Main Activitys onCreate.
+     *
+     * @param app       application instance
+     * @param validPins SHA-256 pins
+     */
+    final public void initWebtrekk(final Application app, Set<String> validPins) {
+        initWebtrekk(app, R.raw.webtrekk_config, validPins);
+    }
+
     /**
      * this initializes the webtrekk tracking configuration, it has to be called only once when the
      * application starts, for example in the Application Class or the Main Activitys onCreate.
@@ -142,7 +153,7 @@ public class Webtrekk implements ActivityListener.Callback {
      * @param c                the application mContext / mContext of the main activity
      * @param configResourceID resource config ID.
      */
-    void initWebtrekk(final Context c, int configResourceID, Set<String> validPins) {
+    final public void initWebtrekk(final Context c, int configResourceID, Set<String> validPins) {
         if (c == null) {
             throw new IllegalArgumentException("no valid mContext");
         }

--- a/webtrekk_sdk/src/main/java/com/webtrekk/webtrekksdk/Webtrekk.java
+++ b/webtrekk_sdk/src/main/java/com/webtrekk/webtrekksdk/Webtrekk.java
@@ -26,19 +26,6 @@ import android.support.annotation.Nullable;
 import android.webkit.JavascriptInterface;
 import android.webkit.WebView;
 
-import com.webtrekk.webtrekksdk.Configuration.ActivityConfiguration;
-import com.webtrekk.webtrekksdk.Configuration.TrackingConfiguration;
-import com.webtrekk.webtrekksdk.Configuration.TrackingConfigurationDownloadTask;
-import com.webtrekk.webtrekksdk.Configuration.TrackingConfigurationXmlParser;
-import com.webtrekk.webtrekksdk.Modules.ExceptionHandler;
-import com.webtrekk.webtrekksdk.Request.RequestFactory;
-import com.webtrekk.webtrekksdk.Request.TrackingRequest;
-import com.webtrekk.webtrekksdk.TrackingParameter.Parameter;
-import com.webtrekk.webtrekksdk.Utils.ActivityListener;
-import com.webtrekk.webtrekksdk.Utils.ActivityTrackingStatus;
-import com.webtrekk.webtrekksdk.Utils.HelperFunctions;
-import com.webtrekk.webtrekksdk.Utils.WebtrekkLogging;
-
 import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.IOException;
@@ -46,6 +33,19 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import com.webtrekk.webtrekksdk.Modules.ExceptionHandler;
+import com.webtrekk.webtrekksdk.Request.RequestFactory;
+import com.webtrekk.webtrekksdk.Request.TrackingRequest;
+import com.webtrekk.webtrekksdk.TrackingParameter.Parameter;
+import com.webtrekk.webtrekksdk.Configuration.ActivityConfiguration;
+import com.webtrekk.webtrekksdk.Utils.ActivityListener;
+import com.webtrekk.webtrekksdk.Utils.ActivityTrackingStatus;
+import com.webtrekk.webtrekksdk.Utils.HelperFunctions;
+import com.webtrekk.webtrekksdk.Configuration.TrackingConfiguration;
+import com.webtrekk.webtrekksdk.Configuration.TrackingConfigurationDownloadTask;
+import com.webtrekk.webtrekksdk.Configuration.TrackingConfigurationXmlParser;
+import com.webtrekk.webtrekksdk.Utils.WebtrekkLogging;
 
 /**
  * The WebtrekkSDK main class, the developer/customer interacts with the SDK through this class.
@@ -89,7 +89,6 @@ public class Webtrekk implements ActivityListener.Callback {
 
     /**
      * public method to get the singleton instance of the webtrekk object,
-     *
      * @return webtrekk instance
      */
     public static Webtrekk getInstance() {
@@ -100,18 +99,17 @@ public class Webtrekk implements ActivityListener.Callback {
      * this initializes the webtrekk tracking configuration, it has to be called only once when the
      * application starts, for example in the Application Class or the Main Activitys onCreate.
      * Use R.raw.webtrekk_config as default configID
-     *
      * @param app application instance
+     *
      */
-    final public void initWebtrekk(final Application app) {
+    final public void initWebtrekk(final Application app)
+    {
         initWebtrekk(app, R.raw.webtrekk_config);
     }
-
 
     /**
      * this initializes the webtrekk tracking configuration, it has to be called only once when the
      * application starts, for example in the Application Class or the Main Activitys onCreate.
-     *
      * @param app       application instance
      * @param validPins SHA-256 pins
      */
@@ -122,9 +120,9 @@ public class Webtrekk implements ActivityListener.Callback {
     /**
      * this initializes the webtrekk tracking configuration, it has to be called only once when the
      * application starts, for example in the Application Class or the Main Activitys onCreate.
-     *
-     * @param app              application instance
+     * @param app application instance
      * @param configResourceID id of config resource
+     *
      */
     final public void initWebtrekk(final Application app, int configResourceID) {
         if (app == null) {
@@ -136,21 +134,22 @@ public class Webtrekk implements ActivityListener.Callback {
     }
 
     /**
-     * @param c
      * @deprecated use {@link #initWebtrekk(Application, int)} instead
      * this initializes the webtrekk tracking configuration, it has to be called only once when the
      * application starts, for example in the Application Class or the Main Activitys onCreate.
      * Use R.raw.webtrekk_config as default configID
+     * @param c
+     *
      */
-    void initWebtrekk(final Context c) {
+    void initWebtrekk(final Context c)
+    {
         initWebtrekk(c, R.raw.webtrekk_config, null);
     }
 
     /**
      * this initializes the webtrekk tracking configuration, it has to be called only once when the
      * application starts, for example in the Application Class or the Main Activitys onCreate
-     *
-     * @param c                the application mContext / mContext of the main activity
+     * @param c the application mContext / mContext of the main activity
      * @param configResourceID resource config ID.
      */
     final public void initWebtrekk(final Context c, int configResourceID, Set<String> validPins) {
@@ -185,10 +184,10 @@ public class Webtrekk implements ActivityListener.Callback {
 
     /**
      * returns if initWebtrekk was called successfully for this object
-     *
      * @return true if initialization was called and false otherwise.
      */
-    public boolean isInitialized() {
+    public boolean isInitialized()
+    {
         return mIsInitialized;
     }
 
@@ -213,12 +212,12 @@ public class Webtrekk implements ActivityListener.Callback {
             try {
                 trackingConfigurationString = HelperFunctions.stringFromStream(mContext.getResources().openRawResource(configResourceID));
             } catch (IOException e) {
-                WebtrekkLogging.log("no custom config was found, illegal state, provide a valid config in res id:" + configResourceID);
+                WebtrekkLogging.log("no custom config was found, illegal state, provide a valid config in res id:"+configResourceID);
                 throw new IllegalStateException("can not load xml configuration file, invalid state");
             }
-            if (trackingConfigurationString.length() < 80) {
+            if(trackingConfigurationString.length() < 80) {
                 // neccesary to make sure it uses the placeholder which has 66 chars length
-                WebtrekkLogging.log("no custom config was found, illegal state, provide a valid config in res id:" + configResourceID);
+                WebtrekkLogging.log("no custom config was found, illegal state, provide a valid config in res id:"+configResourceID);
                 throw new IllegalStateException("can not load xml configuration file, invalid state");
             }
         } else {
@@ -229,13 +228,13 @@ public class Webtrekk implements ActivityListener.Callback {
             // parse default configuration without default, will throw exceptions when its not valid
             trackingConfiguration = new TrackingConfigurationXmlParser().parse(trackingConfigurationString);
         } catch (Exception e) {
-            throw new IllegalStateException("invalid xml configuration file, invalid state: " + e.getMessage() + "\n" + trackingConfigurationString);
+            throw new IllegalStateException("invalid xml configuration file, invalid state: " + e.getMessage() + "\n"+trackingConfigurationString);
         }
 
-        if (trackingConfiguration != null && trackingConfiguration.isEnableRemoteConfiguration()) {
+        if(trackingConfiguration != null && trackingConfiguration.isEnableRemoteConfiguration()) {
             SharedPreferences sharedPrefs = HelperFunctions.getWebTrekkSharedPreference(mContext);
             // second check if a newer remote config version is stored locally
-            if (sharedPrefs.contains(Webtrekk.PREFERENCE_KEY_CONFIGURATION)) {
+            if(sharedPrefs.contains(Webtrekk.PREFERENCE_KEY_CONFIGURATION)) {
                 WebtrekkLogging.log("found trackingConfiguration in preferences");
                 // in this case we already have a configuration xml stored
                 // parse the existing one and check if an update is online available
@@ -243,13 +242,13 @@ public class Webtrekk implements ActivityListener.Callback {
                 TrackingConfiguration sharedPreferencetrackingConfiguration = null;
                 try {
                     sharedPreferencetrackingConfiguration = new TrackingConfigurationXmlParser().parse(trackingConfigurationString);
-                    if (sharedPreferencetrackingConfiguration.getVersion() > trackingConfiguration.getVersion()) {
+                    if(sharedPreferencetrackingConfiguration.getVersion() > trackingConfiguration.getVersion()) {
                         // in this case there is a newer, so replace th old one
                         trackingConfiguration = sharedPreferencetrackingConfiguration;
                     }
                 } catch (IOException e) {
                     WebtrekkLogging.log("ioexception parsing the configuration string", e);
-                } catch (XmlPullParserException e) {
+                } catch(XmlPullParserException e) {
                     WebtrekkLogging.log("exception parsing the configuration string", e);
                 }
 
@@ -261,12 +260,12 @@ public class Webtrekk implements ActivityListener.Callback {
         }
 
         // check if we have a valid configuration
-        if (trackingConfiguration != null && trackingConfiguration.validateConfiguration()) {
+        if(trackingConfiguration != null && trackingConfiguration.validateConfiguration()) {
             WebtrekkLogging.log("xml trackingConfiguration value: trackid - " + trackingConfiguration.getTrackId());
             WebtrekkLogging.log("xml trackingConfiguration value: trackdomain - " + trackingConfiguration.getTrackDomain());
             WebtrekkLogging.log("xml trackingConfiguration value: send_delay - " + trackingConfiguration.getSendDelay());
 
-            for (ActivityConfiguration cfg : trackingConfiguration.getActivityConfigurations().values()) {
+            for(ActivityConfiguration cfg : trackingConfiguration.getActivityConfigurations().values()) {
                 WebtrekkLogging.log("xml trackingConfiguration activity for: " + cfg.getClassName() + " mapped to: " + cfg.getMappingName() + " autotracked: " + cfg.isAutoTrack());
             }
         } else {
@@ -280,11 +279,10 @@ public class Webtrekk implements ActivityListener.Callback {
 
     /**
      * this functions enables the automatic activity tracking in case its enabled in the configuration
-     *
      * @param app application object of the tracked app, can either be a custom one or required by getApplication()
      */
-    void initAutoTracking(Application app) {
-        if (mActivityStatus == null) {
+    void initAutoTracking(Application app){
+        if(mActivityStatus == null) {
             WebtrekkLogging.log("enabling callbacks");
             mActivityStatus = new ActivityListener(this);
             mActivityStatus.init(app);
@@ -297,7 +295,7 @@ public class Webtrekk implements ActivityListener.Callback {
      * tracking will be in invalid state, until init is called again
      */
     public void stopTracking() {
-        if (mRequestFactory.getRequestUrlStore() != null) {
+        if(mRequestFactory.getRequestUrlStore() != null) {
             mRequestFactory.stopSendURLProcess();
             mRequestFactory.getRequestUrlStore().clearAllTrackingData();
         }
@@ -305,7 +303,6 @@ public class Webtrekk implements ActivityListener.Callback {
 
     /**
      * checks if logging is enabled
-     *
      * @return boolean if logging is enabled
      */
     public static boolean isLoggingEnabled() {
@@ -314,7 +311,6 @@ public class Webtrekk implements ActivityListener.Callback {
 
     /**
      * enables the logging for all SDK log outputs
-     *
      * @param logging enables/disables the webtrekk logging
      */
     public static void setLoggingEnabled(boolean logging) {
@@ -339,8 +335,9 @@ public class Webtrekk implements ActivityListener.Callback {
     }
 
     /**
+     * @deprecated
+     * Don't call this function. If you need override page name call {@link Webtrekk#setCustomPageName(String)} instead
      * @param currentActivityName
-     * @deprecated Don't call this function. If you need override page name call {@link Webtrekk#setCustomPageName(String)} instead
      */
     public void setCurrentActivityName(String currentActivityName) {
         mRequestFactory.setCurrentActivityName(currentActivityName);
@@ -348,11 +345,11 @@ public class Webtrekk implements ActivityListener.Callback {
 
     /**
      * set custom page name. This name overrides page name that either provided by activity name or
-     * set in <mappingname> tag in configuration xml. name is cleaned on next activity start.
-     *
+     *set in <mappingname> tag in configuration xml. name is cleaned on next activity start.
      * @param pageName
      */
-    public void setCustomPageName(String pageName) {
+    public void setCustomPageName(String pageName)
+    {
         mRequestFactory.setCustomPageName(pageName);
     }
 
@@ -371,10 +368,10 @@ public class Webtrekk implements ActivityListener.Callback {
         // only track if auto tracking is enabled for that activity
         // the default value and the activities autoTracked value is based on the global xml settings
         boolean autoTrack = trackingConfiguration.isAutoTracked();
-        if (trackingConfiguration.getActivityConfigurations() != null && trackingConfiguration.getActivityConfigurations().containsKey(mRequestFactory.getCurrentActivityName())) {
+        if(trackingConfiguration.getActivityConfigurations()!= null && trackingConfiguration.getActivityConfigurations().containsKey(mRequestFactory.getCurrentActivityName())) {
             autoTrack = trackingConfiguration.getActivityConfigurations().get(mRequestFactory.getCurrentActivityName()).isAutoTrack();
         }
-        if (autoTrack) {
+        if(autoTrack) {
             track();
         }
     }
@@ -396,18 +393,18 @@ public class Webtrekk implements ActivityListener.Callback {
             return;
         }
 
-        if (tp == null) {
+        if(tp == null) {
             WebtrekkLogging.log("TrackingParams is null");
             return;
         }
 
         boolean addCDBRequestType = false;
 
-        if (WebtrekkUserParameters.needUpdateCDBRequest(mContext)) {
+        if (WebtrekkUserParameters.needUpdateCDBRequest(mContext)){
 
             WebtrekkUserParameters userPar = new WebtrekkUserParameters();
 
-            if (userPar.restoreFromSettings(mContext)) {
+            if (userPar.restoreFromSettings(mContext)){
                 tp.add(userPar.getParameters());
                 tp.setCustomUserParameters(userPar.getCustomParameters());
                 addCDBRequestType = true;
@@ -416,7 +413,7 @@ public class Webtrekk implements ActivityListener.Callback {
 
         TrackingRequest request = mRequestFactory.createTrackingRequest(tp);
 
-        if (addCDBRequestType) {
+        if (addCDBRequestType){
             request.setMergedRequest(TrackingRequest.RequestType.CDB);
         }
 
@@ -430,10 +427,10 @@ public class Webtrekk implements ActivityListener.Callback {
      * webtrekk.track(new WebtrekkUserParameters.</br>
      * setEmail("some email").</br>
      * setPhone("some phone"))
-     *
      * @param userParameters - user parameters
      */
-    public void track(WebtrekkUserParameters userParameters) {
+    public void track(WebtrekkUserParameters userParameters)
+    {
         if (userParameters.saveToSettings(mContext))
             WebtrekkLogging.log("CDB request is received and saved to settings");
         else {
@@ -454,17 +451,16 @@ public class Webtrekk implements ActivityListener.Callback {
 
     /**
      * track exception that is caught by internal application handler.
-     *
      * @param ex - caught exception
      */
-    public void trackException(Throwable ex) {
+    public void trackException(Throwable ex)
+    {
         mExceptionHandler.trackCatched(ex);
     }
 
     /**
      * track exception info that user can provide.
-     *
-     * @param name    max 255 characters
+     * @param name max 255 characters
      * @param message max 255 characters
      */
     public void trackException(String name, String message) {
@@ -473,9 +469,8 @@ public class Webtrekk implements ActivityListener.Callback {
 
     /**
      * this function is be called automatically by activity flow listener
-     *
      * @hide
-     */
+     * */
     @Override
     public void onStart(boolean isRecreationInProcess, ActivityTrackingStatus.STATUS status,
                         long inactivityTime, String activityName) {
@@ -490,12 +485,12 @@ public class Webtrekk implements ActivityListener.Callback {
             mRequestFactory.setCurrentActivityName(activityName);
         }
 
-        if (status == ActivityTrackingStatus.STATUS.FIRST_ACTIVITY_STARTED) {
+        if(status == ActivityTrackingStatus.STATUS.FIRST_ACTIVITY_STARTED) {
             onFirstActivityStart();
         }
 
         // track only if it isn't in background and session timeout isn't passed
-        if (status == ActivityTrackingStatus.STATUS.RETURNINIG_FROM_BACKGROUND) {
+        if (status == ActivityTrackingStatus.STATUS.RETURNINIG_FROM_BACKGROUND){
             if (inactivityTime > trackingConfiguration.getResendOnStartEventTime())
                 mRequestFactory.forceNewSession();
             mRequestFactory.restore();
@@ -507,8 +502,7 @@ public class Webtrekk implements ActivityListener.Callback {
     /**
      * this method gets called when the first activity of the application has started
      * it loads the old requests from the backupfile and tries to send them
-     *
-     * @hide
+     *@hide
      */
     private void onFirstActivityStart() {
         mRequestFactory.onFirstStart();
@@ -518,7 +512,6 @@ public class Webtrekk implements ActivityListener.Callback {
     /**
      * this function is be called automatically by activity flow listener
      * open activities and knows when to exit
-     *
      * @hide
      */
     @Override
@@ -527,7 +520,8 @@ public class Webtrekk implements ActivityListener.Callback {
             throw new IllegalStateException("webtrekk has not been initialized");
         }
 
-        switch (status) {
+        switch (status)
+        {
             case SHUT_DOWNING:
                 stop();
                 break;
@@ -538,12 +532,14 @@ public class Webtrekk implements ActivityListener.Callback {
     }
 
     /**
-     * @hide Is called when activity is destroyed to double check that queries are saved and threads are stopped
+     * @hide
+     * Is called when activity is destroyed to double check that queries are saved and threads are stopped
      * as in some cases stop isn't called during application showt down.
      */
     @Override
-    public void onDestroy(ActivityTrackingStatus.STATUS status) {
-        if (status == ActivityTrackingStatus.STATUS.SHUT_DOWNING) {
+    public void onDestroy(ActivityTrackingStatus.STATUS status)
+    {
+        if(status == ActivityTrackingStatus.STATUS.SHUT_DOWNING) {
             stop();
         }
     }
@@ -551,7 +547,6 @@ public class Webtrekk implements ActivityListener.Callback {
     /**
      * this method gets called when application is going to be closed
      * it stores all requests to file and stop threads.
-     *
      * @hide
      */
     void stop() {
@@ -570,7 +565,8 @@ public class Webtrekk implements ActivityListener.Callback {
         this.mContext = context;
     }
 
-    RequestFactory getRequestFactory() {
+    RequestFactory getRequestFactory()
+    {
         return mRequestFactory;
     }
 
@@ -583,7 +579,6 @@ public class Webtrekk implements ActivityListener.Callback {
     /**
      * this method is for the opt out switch, when called it will set the shared preferences of opt out
      * and also stops tracking in case the user opts out
-     *
      * @param value boolean value indicating if the user opted out or not
      */
     public void setOptout(boolean value) {
@@ -593,18 +588,18 @@ public class Webtrekk implements ActivityListener.Callback {
     /**
      * Set url for tracking for each activity. This value is reset for each new activity
      * Value is override PAGE_URL parameter in activity configuration if any.
-     *
      * @param url
      * @return
      */
 
-    public boolean setPageURL(String url) {
+    public boolean setPageURL(String url)
+    {
         ActivityConfiguration acConf = trackingConfiguration.getActivityConfigurations().get(mRequestFactory.getCurrentActivityName());
 
         if (!HelperFunctions.testIsValidURL(url)) {
             WebtrekkLogging.log("setPageURL. Invalid url format");
             return false;
-        } else {
+        }else {
 
             if (acConf != null) {
                 acConf.setOverridenPageURL(url);
@@ -617,7 +612,8 @@ public class Webtrekk implements ActivityListener.Callback {
     }
 
     //reset overrated URLTrack
-    private void resetPageURLTrack() {
+    private void resetPageURLTrack()
+    {
         ActivityConfiguration acConf = trackingConfiguration.getActivityConfigurations().get(mRequestFactory.getCurrentActivityName());
 
         if (acConf != null)
@@ -629,29 +625,28 @@ public class Webtrekk implements ActivityListener.Callback {
      * Each time method returns new instance of recommendation object that is initialized accornding to
      * configuration xml. Using WebtrekkRecommendations object you can have independed several recommendation
      * request.
-     *
      * @return WebtrekkRecommendations object
      */
-    public WebtrekkRecommendations getRecommendations() {
+    public WebtrekkRecommendations getRecommendations()
+    {
         return new WebtrekkRecommendations(trackingConfiguration, mContext);
     }
 
 
-    public ProductListTracker getProductListTracker() {
+    public ProductListTracker getProductListTracker(){
         return mProductListTracker;
     }
 
     /**
      * Send manual tracks to server from tracks queue. Is done in separate thread and can be called from UI thread.
      * It must be called when <sendDelay> is zero, otherwise no message is sent to server.
-     *
      * @return true if sending is called and false if previous send procedure hasn't called or nothing to send
-     * or manual send mode is off (<sendDelay> not zero).
+     *              or manual send mode is off (<sendDelay> not zero).
      */
     public boolean send() {
         if (mRequestFactory.getTrackingConfiguration().getSendDelay() == 0) {
             return mRequestFactory.onSendIntervalOver();
-        } else {
+        }else {
             WebtrekkLogging.log("Custom url send mode isn't switched on. Send isn't available. For custom send mode set <sendDelay> to zero ");
             return false;
         }
@@ -659,7 +654,6 @@ public class Webtrekk implements ActivityListener.Callback {
 
     /**
      * allows to set global tracking parameter which will be added to all requests
-     *
      * @return
      */
     public TrackingParameter getGlobalTrackingParameter() {
@@ -689,14 +683,14 @@ public class Webtrekk implements ActivityListener.Callback {
 
     /**
      * this method alles the customer to set the custom parameters map
+     *
      */
     public void setCustomParameter(Map<String, String> customParameter) {
         mRequestFactory.setCustomParameter(customParameter);
     }
 
     /**
-     * Returns current EverId. EverId is generated automatically by SDK, but you can set is manual as well.
-     *
+     *Returns current EverId. EverId is generated automatically by SDK, but you can set is manual as well.
      * @return current EverId
      */
     public String getEverId() {
@@ -706,30 +700,31 @@ public class Webtrekk implements ActivityListener.Callback {
     /**
      * Returns Tracking ID list defined in configuration xml. In most cased it is one item,
      * but theoretically it can be list divided by commas. null if Webtrekk is not initialized.
-     *
      * @return current Tracking ID
      */
     public List<String> getTrackingIDs() {
-        if (trackingConfiguration == null) {
+        if (trackingConfiguration == null){
             WebtrekkLogging.log("webtrekk has not been initialized");
             return null;
-        } else {
+        }else {
             return Arrays.asList(trackingConfiguration.getTrackId().split(","));
         }
     }
 
     /**
      * set EverId. This ever ID will be used for all tracking request until application reinstall.
-     *
      * @param everId - 19 digits string value
      */
-    public void setEverId(String everId) {
-        if (mContext == null) {
+    public void setEverId(String everId)
+    {
+        if (mContext == null)
+        {
             WebtrekkLogging.log("Can't set ever id. Please initialize SDK first.");
             return;
         }
 
-        if (!everId.matches("\\d{19}")) {
+        if (!everId.matches("\\d{19}"))
+        {
             WebtrekkLogging.log("Incorrect everID should have 19 digits");
             return;
         }
@@ -740,11 +735,12 @@ public class Webtrekk implements ActivityListener.Callback {
 
     /**
      * Set deeplink attribution media code. This media code will be sent once with the next tracking request
-     *
      * @param mediaCode - media code
      */
-    public void setMediaCode(String mediaCode) {
-        if (mContext == null) {
+    public void setMediaCode(String mediaCode)
+    {
+        if (mContext == null)
+        {
             WebtrekkLogging.log("Can't set media code. Please initialize SDK first.");
             return;
         }
@@ -754,15 +750,15 @@ public class Webtrekk implements ActivityListener.Callback {
 
     //class for webVeiwCallback
 
-    static class AndroidWebViewCallback {
+    static class AndroidWebViewCallback{
         private final Context mContext;
 
-        AndroidWebViewCallback(@Nullable Context context) {
+        AndroidWebViewCallback(@Nullable Context context){
             mContext = context;
         }
 
         @JavascriptInterface
-        public String getEverId() {
+        public String getEverId(){
             return HelperFunctions.getEverId(mContext);
         }
     }
@@ -775,24 +771,23 @@ public class Webtrekk implements ActivityListener.Callback {
      *
      * @param webView - webView instance can't be null
      */
-    public void setupWebView(WebView webView) {
-        if (mContext == null) {
+    public void setupWebView(WebView webView){
+        if (mContext == null){
             WebtrekkLogging.log("Can't setup WebView. Please initialize SDK first.");
             return;
         }
 
-        if (webView == null) {
+        if (webView == null){
             WebtrekkLogging.log("Can't setup WebView. WebView parameter is null.");
             return;
         }
 
-        if (Looper.getMainLooper().getThread() != Thread.currentThread()) {
+        if (Looper.getMainLooper().getThread() != Thread.currentThread()){
             WebtrekkLogging.log("Can't setup WebView. Function should be called from UI thread.");
             return;
         }
 
         final String everId = HelperFunctions.getEverId(mContext);
-        ;
 
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
             webView.addJavascriptInterface(new AndroidWebViewCallback(mContext), "WebtrekkAndroidWebViewCallback");
@@ -802,16 +797,16 @@ public class Webtrekk implements ActivityListener.Callback {
     }
 
     /**
-     * @return
      * @hide
+     * @return
      */
     public TrackingConfiguration getTrackingConfiguration() {
         return trackingConfiguration;
     }
 
     /**
-     * @param trackingConfiguration
      * @hide
+     * @param trackingConfiguration
      */
     public void setTrackingConfiguration(TrackingConfiguration trackingConfiguration) {
         this.trackingConfiguration = trackingConfiguration;
@@ -819,66 +814,35 @@ public class Webtrekk implements ActivityListener.Callback {
     }
 
     /**
-     * @param context
      * @hide
+     * @param context
      */
-    private void initVersions(Context context) {
+    private void initVersions(Context context)
+    {
         mTrackingLibraryVersionUI = context.getResources().getString(R.string.version_name);
-        mTrackingLibraryVersion = mTrackingLibraryVersionUI.replaceAll("\\D", "");
+        mTrackingLibraryVersion = mTrackingLibraryVersionUI.replaceAll("\\D","");
     }
 
     /**
      * for unit testing in the application and debugging
      */
-    public int getVersion() {
-        return trackingConfiguration.getVersion();
-    }
-
-    public String getTrackDomain() {
-        return trackingConfiguration.getTrackDomain();
-    }
-
-    public int getSampling() {
-        return trackingConfiguration.getSampling();
-    }
-
-    public void setIsSampling(boolean isSampling) {
-        mRequestFactory.setIsSampling(isSampling);
-    }
-
-    public int getSendDelay() {
-        return trackingConfiguration.getSendDelay();
-    }
-
-    public int getResendOnStartEventTime() {
-        return trackingConfiguration.getResendOnStartEventTime();
-    }
-
-    public int getMaxRequests() {
-        return trackingConfiguration.getMaxRequests();
-    }
-
-    public String getTrackingConfigurationUrl() {
-        return trackingConfiguration.getTrackingConfigurationUrl();
-    }
-
-    public boolean isAutoTracked() {
-        return trackingConfiguration.isAutoTracked();
-    }
-
-    public boolean isAutoTrackApiLevel() {
-        return trackingConfiguration.isAutoTrackApiLevel();
-    }
-
-    public boolean isEnableRemoteConfiguration() {
-        return trackingConfiguration.isEnableRemoteConfiguration();
-    }
+    public int getVersion() { return trackingConfiguration.getVersion(); }
+    public String getTrackDomain() { return trackingConfiguration.getTrackDomain(); }
+    public int getSampling() { return trackingConfiguration.getSampling(); }
+    public void setIsSampling(boolean isSampling ) { mRequestFactory.setIsSampling(isSampling); }
+    public int getSendDelay() { return trackingConfiguration.getSendDelay(); }
+    public int getResendOnStartEventTime() { return trackingConfiguration.getResendOnStartEventTime(); }
+    public int getMaxRequests() { return trackingConfiguration.getMaxRequests(); }
+    public String getTrackingConfigurationUrl() { return trackingConfiguration.getTrackingConfigurationUrl(); }
+    public boolean isAutoTracked() { return trackingConfiguration.isAutoTracked(); }
+    public boolean isAutoTrackApiLevel() { return trackingConfiguration.isAutoTrackApiLevel(); }
+    public boolean isEnableRemoteConfiguration() { return trackingConfiguration.isEnableRemoteConfiguration(); }
 
     /**
-     * @return
      * @deprecated use {@link #getTrackingIDs()} instead
+     * @return
      */
-    public String getTrackId() {
+    public String getTrackId(){
         return getTrackingIDs().get(0);
     }
 }

--- a/webtrekk_sdk/src/main/java/com/webtrekk/webtrekksdk/Webtrekk.java
+++ b/webtrekk_sdk/src/main/java/com/webtrekk/webtrekksdk/Webtrekk.java
@@ -26,25 +26,27 @@ import android.support.annotation.Nullable;
 import android.webkit.JavascriptInterface;
 import android.webkit.WebView;
 
-import org.xmlpull.v1.XmlPullParserException;
-
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-
+import com.webtrekk.webtrekksdk.Configuration.ActivityConfiguration;
+import com.webtrekk.webtrekksdk.Configuration.TrackingConfiguration;
+import com.webtrekk.webtrekksdk.Configuration.TrackingConfigurationDownloadTask;
+import com.webtrekk.webtrekksdk.Configuration.TrackingConfigurationXmlParser;
 import com.webtrekk.webtrekksdk.Modules.ExceptionHandler;
 import com.webtrekk.webtrekksdk.Request.RequestFactory;
 import com.webtrekk.webtrekksdk.Request.TrackingRequest;
 import com.webtrekk.webtrekksdk.TrackingParameter.Parameter;
-import com.webtrekk.webtrekksdk.Configuration.ActivityConfiguration;
 import com.webtrekk.webtrekksdk.Utils.ActivityListener;
 import com.webtrekk.webtrekksdk.Utils.ActivityTrackingStatus;
 import com.webtrekk.webtrekksdk.Utils.HelperFunctions;
-import com.webtrekk.webtrekksdk.Configuration.TrackingConfiguration;
-import com.webtrekk.webtrekksdk.Configuration.TrackingConfigurationDownloadTask;
-import com.webtrekk.webtrekksdk.Configuration.TrackingConfigurationXmlParser;
 import com.webtrekk.webtrekksdk.Utils.WebtrekkLogging;
+
+import org.xmlpull.v1.XmlPullParserException;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * The WebtrekkSDK main class, the developer/customer interacts with the SDK through this class.
@@ -88,6 +90,7 @@ public class Webtrekk implements ActivityListener.Callback {
 
     /**
      * public method to get the singleton instance of the webtrekk object,
+     *
      * @return webtrekk instance
      */
     public static Webtrekk getInstance() {
@@ -98,20 +101,19 @@ public class Webtrekk implements ActivityListener.Callback {
      * this initializes the webtrekk tracking configuration, it has to be called only once when the
      * application starts, for example in the Application Class or the Main Activitys onCreate.
      * Use R.raw.webtrekk_config as default configID
-     * @param app application instance
      *
+     * @param app application instance
      */
-    final public void initWebtrekk(final Application app)
-    {
+    final public void initWebtrekk(final Application app) {
         initWebtrekk(app, R.raw.webtrekk_config);
     }
 
     /**
      * this initializes the webtrekk tracking configuration, it has to be called only once when the
      * application starts, for example in the Application Class or the Main Activitys onCreate.
-     * @param app application instance
-     * @param configResourceID id of config resource
      *
+     * @param app              application instance
+     * @param configResourceID id of config resource
      */
     final public void initWebtrekk(final Application app, int configResourceID) {
         if (app == null) {
@@ -119,29 +121,28 @@ public class Webtrekk implements ActivityListener.Callback {
         }
         initVersions(app.getApplicationContext());
         initAutoTracking(app);
-        initWebtrekk(app.getApplicationContext(), configResourceID);
+        initWebtrekk(app.getApplicationContext(), configResourceID, null);
     }
 
     /**
+     * @param c
      * @deprecated use {@link #initWebtrekk(Application, int)} instead
      * this initializes the webtrekk tracking configuration, it has to be called only once when the
      * application starts, for example in the Application Class or the Main Activitys onCreate.
      * Use R.raw.webtrekk_config as default configID
-     * @param c
-     *
      */
-    void initWebtrekk(final Context c)
-    {
-        initWebtrekk(c, R.raw.webtrekk_config);
+    void initWebtrekk(final Context c) {
+        initWebtrekk(c, R.raw.webtrekk_config, null);
     }
 
     /**
      * this initializes the webtrekk tracking configuration, it has to be called only once when the
      * application starts, for example in the Application Class or the Main Activitys onCreate
-     * @param c the application mContext / mContext of the main activity
+     *
+     * @param c                the application mContext / mContext of the main activity
      * @param configResourceID resource config ID.
      */
-    void initWebtrekk(final Context c, int configResourceID) {
+    void initWebtrekk(final Context c, int configResourceID, Set<String> validPins) {
         if (c == null) {
             throw new IllegalArgumentException("no valid mContext");
         }
@@ -156,7 +157,7 @@ public class Webtrekk implements ActivityListener.Callback {
         boolean isFirstStart = HelperFunctions.firstStart(mContext);
 
         initTrackingConfiguration(configResourceID);
-        mRequestFactory.init(mContext, trackingConfiguration, this);
+        mRequestFactory.init(mContext, trackingConfiguration, this, validPins);
         //TODO: make sure this can not break
         //Application act = (Application) mContext.getApplicationContext();
         mExceptionHandler.init(mRequestFactory, mContext);
@@ -173,10 +174,10 @@ public class Webtrekk implements ActivityListener.Callback {
 
     /**
      * returns if initWebtrekk was called successfully for this object
+     *
      * @return true if initialization was called and false otherwise.
      */
-    public boolean isInitialized()
-    {
+    public boolean isInitialized() {
         return mIsInitialized;
     }
 
@@ -193,37 +194,37 @@ public class Webtrekk implements ActivityListener.Callback {
      */
     final void initTrackingConfiguration(final String configurationString, int configResourceID) {
 
-            // always parse the local raw config version first, this is fallback, default and also the way to fix broken online configs
-            //TODO: this could me more elegant by only parsing it when its a new app version which needs to be set anyway
-            String trackingConfigurationString;
-            String defaultConfigurationString = null;
-            if (configurationString == null) {
-                try {
-                    trackingConfigurationString = HelperFunctions.stringFromStream(mContext.getResources().openRawResource(configResourceID));
-                } catch (IOException e) {
-                    WebtrekkLogging.log("no custom config was found, illegal state, provide a valid config in res id:"+configResourceID);
-                    throw new IllegalStateException("can not load xml configuration file, invalid state");
-                }
-                if(trackingConfigurationString.length() < 80) {
-                    // neccesary to make sure it uses the placeholder which has 66 chars length
-                    WebtrekkLogging.log("no custom config was found, illegal state, provide a valid config in res id:"+configResourceID);
-                    throw new IllegalStateException("can not load xml configuration file, invalid state");
-                }
-            } else {
-                trackingConfigurationString = configurationString;
+        // always parse the local raw config version first, this is fallback, default and also the way to fix broken online configs
+        //TODO: this could me more elegant by only parsing it when its a new app version which needs to be set anyway
+        String trackingConfigurationString;
+        String defaultConfigurationString = null;
+        if (configurationString == null) {
+            try {
+                trackingConfigurationString = HelperFunctions.stringFromStream(mContext.getResources().openRawResource(configResourceID));
+            } catch (IOException e) {
+                WebtrekkLogging.log("no custom config was found, illegal state, provide a valid config in res id:" + configResourceID);
+                throw new IllegalStateException("can not load xml configuration file, invalid state");
             }
+            if (trackingConfigurationString.length() < 80) {
+                // neccesary to make sure it uses the placeholder which has 66 chars length
+                WebtrekkLogging.log("no custom config was found, illegal state, provide a valid config in res id:" + configResourceID);
+                throw new IllegalStateException("can not load xml configuration file, invalid state");
+            }
+        } else {
+            trackingConfigurationString = configurationString;
+        }
 
         try {
             // parse default configuration without default, will throw exceptions when its not valid
             trackingConfiguration = new TrackingConfigurationXmlParser().parse(trackingConfigurationString);
         } catch (Exception e) {
-            throw new IllegalStateException("invalid xml configuration file, invalid state: " + e.getMessage() + "\n"+trackingConfigurationString);
+            throw new IllegalStateException("invalid xml configuration file, invalid state: " + e.getMessage() + "\n" + trackingConfigurationString);
         }
 
-        if(trackingConfiguration != null && trackingConfiguration.isEnableRemoteConfiguration()) {
+        if (trackingConfiguration != null && trackingConfiguration.isEnableRemoteConfiguration()) {
             SharedPreferences sharedPrefs = HelperFunctions.getWebTrekkSharedPreference(mContext);
             // second check if a newer remote config version is stored locally
-            if(sharedPrefs.contains(Webtrekk.PREFERENCE_KEY_CONFIGURATION)) {
+            if (sharedPrefs.contains(Webtrekk.PREFERENCE_KEY_CONFIGURATION)) {
                 WebtrekkLogging.log("found trackingConfiguration in preferences");
                 // in this case we already have a configuration xml stored
                 // parse the existing one and check if an update is online available
@@ -231,13 +232,13 @@ public class Webtrekk implements ActivityListener.Callback {
                 TrackingConfiguration sharedPreferencetrackingConfiguration = null;
                 try {
                     sharedPreferencetrackingConfiguration = new TrackingConfigurationXmlParser().parse(trackingConfigurationString);
-                    if(sharedPreferencetrackingConfiguration.getVersion() > trackingConfiguration.getVersion()) {
+                    if (sharedPreferencetrackingConfiguration.getVersion() > trackingConfiguration.getVersion()) {
                         // in this case there is a newer, so replace th old one
                         trackingConfiguration = sharedPreferencetrackingConfiguration;
                     }
                 } catch (IOException e) {
                     WebtrekkLogging.log("ioexception parsing the configuration string", e);
-                } catch(XmlPullParserException e) {
+                } catch (XmlPullParserException e) {
                     WebtrekkLogging.log("exception parsing the configuration string", e);
                 }
 
@@ -249,12 +250,12 @@ public class Webtrekk implements ActivityListener.Callback {
         }
 
         // check if we have a valid configuration
-        if(trackingConfiguration != null && trackingConfiguration.validateConfiguration()) {
+        if (trackingConfiguration != null && trackingConfiguration.validateConfiguration()) {
             WebtrekkLogging.log("xml trackingConfiguration value: trackid - " + trackingConfiguration.getTrackId());
             WebtrekkLogging.log("xml trackingConfiguration value: trackdomain - " + trackingConfiguration.getTrackDomain());
             WebtrekkLogging.log("xml trackingConfiguration value: send_delay - " + trackingConfiguration.getSendDelay());
 
-            for(ActivityConfiguration cfg : trackingConfiguration.getActivityConfigurations().values()) {
+            for (ActivityConfiguration cfg : trackingConfiguration.getActivityConfigurations().values()) {
                 WebtrekkLogging.log("xml trackingConfiguration activity for: " + cfg.getClassName() + " mapped to: " + cfg.getMappingName() + " autotracked: " + cfg.isAutoTrack());
             }
         } else {
@@ -268,10 +269,11 @@ public class Webtrekk implements ActivityListener.Callback {
 
     /**
      * this functions enables the automatic activity tracking in case its enabled in the configuration
+     *
      * @param app application object of the tracked app, can either be a custom one or required by getApplication()
      */
-    void initAutoTracking(Application app){
-        if(mActivityStatus == null) {
+    void initAutoTracking(Application app) {
+        if (mActivityStatus == null) {
             WebtrekkLogging.log("enabling callbacks");
             mActivityStatus = new ActivityListener(this);
             mActivityStatus.init(app);
@@ -284,7 +286,7 @@ public class Webtrekk implements ActivityListener.Callback {
      * tracking will be in invalid state, until init is called again
      */
     public void stopTracking() {
-        if(mRequestFactory.getRequestUrlStore() != null) {
+        if (mRequestFactory.getRequestUrlStore() != null) {
             mRequestFactory.stopSendURLProcess();
             mRequestFactory.getRequestUrlStore().clearAllTrackingData();
         }
@@ -292,6 +294,7 @@ public class Webtrekk implements ActivityListener.Callback {
 
     /**
      * checks if logging is enabled
+     *
      * @return boolean if logging is enabled
      */
     public static boolean isLoggingEnabled() {
@@ -300,6 +303,7 @@ public class Webtrekk implements ActivityListener.Callback {
 
     /**
      * enables the logging for all SDK log outputs
+     *
      * @param logging enables/disables the webtrekk logging
      */
     public static void setLoggingEnabled(boolean logging) {
@@ -324,9 +328,8 @@ public class Webtrekk implements ActivityListener.Callback {
     }
 
     /**
-     * @deprecated
-     * Don't call this function. If you need override page name call {@link Webtrekk#setCustomPageName(String)} instead
      * @param currentActivityName
+     * @deprecated Don't call this function. If you need override page name call {@link Webtrekk#setCustomPageName(String)} instead
      */
     public void setCurrentActivityName(String currentActivityName) {
         mRequestFactory.setCurrentActivityName(currentActivityName);
@@ -334,11 +337,11 @@ public class Webtrekk implements ActivityListener.Callback {
 
     /**
      * set custom page name. This name overrides page name that either provided by activity name or
-     *set in <mappingname> tag in configuration xml. name is cleaned on next activity start.
+     * set in <mappingname> tag in configuration xml. name is cleaned on next activity start.
+     *
      * @param pageName
      */
-    public void setCustomPageName(String pageName)
-    {
+    public void setCustomPageName(String pageName) {
         mRequestFactory.setCustomPageName(pageName);
     }
 
@@ -357,10 +360,10 @@ public class Webtrekk implements ActivityListener.Callback {
         // only track if auto tracking is enabled for that activity
         // the default value and the activities autoTracked value is based on the global xml settings
         boolean autoTrack = trackingConfiguration.isAutoTracked();
-        if(trackingConfiguration.getActivityConfigurations()!= null && trackingConfiguration.getActivityConfigurations().containsKey(mRequestFactory.getCurrentActivityName())) {
+        if (trackingConfiguration.getActivityConfigurations() != null && trackingConfiguration.getActivityConfigurations().containsKey(mRequestFactory.getCurrentActivityName())) {
             autoTrack = trackingConfiguration.getActivityConfigurations().get(mRequestFactory.getCurrentActivityName()).isAutoTrack();
         }
-        if(autoTrack) {
+        if (autoTrack) {
             track();
         }
     }
@@ -382,18 +385,18 @@ public class Webtrekk implements ActivityListener.Callback {
             return;
         }
 
-        if(tp == null) {
+        if (tp == null) {
             WebtrekkLogging.log("TrackingParams is null");
             return;
         }
 
         boolean addCDBRequestType = false;
 
-        if (WebtrekkUserParameters.needUpdateCDBRequest(mContext)){
+        if (WebtrekkUserParameters.needUpdateCDBRequest(mContext)) {
 
             WebtrekkUserParameters userPar = new WebtrekkUserParameters();
 
-            if (userPar.restoreFromSettings(mContext)){
+            if (userPar.restoreFromSettings(mContext)) {
                 tp.add(userPar.getParameters());
                 tp.setCustomUserParameters(userPar.getCustomParameters());
                 addCDBRequestType = true;
@@ -402,7 +405,7 @@ public class Webtrekk implements ActivityListener.Callback {
 
         TrackingRequest request = mRequestFactory.createTrackingRequest(tp);
 
-        if (addCDBRequestType){
+        if (addCDBRequestType) {
             request.setMergedRequest(TrackingRequest.RequestType.CDB);
         }
 
@@ -416,10 +419,10 @@ public class Webtrekk implements ActivityListener.Callback {
      * webtrekk.track(new WebtrekkUserParameters.</br>
      * setEmail("some email").</br>
      * setPhone("some phone"))
+     *
      * @param userParameters - user parameters
      */
-    public void track(WebtrekkUserParameters userParameters)
-    {
+    public void track(WebtrekkUserParameters userParameters) {
         if (userParameters.saveToSettings(mContext))
             WebtrekkLogging.log("CDB request is received and saved to settings");
         else {
@@ -440,16 +443,17 @@ public class Webtrekk implements ActivityListener.Callback {
 
     /**
      * track exception that is caught by internal application handler.
+     *
      * @param ex - caught exception
      */
-    public void trackException(Throwable ex)
-    {
+    public void trackException(Throwable ex) {
         mExceptionHandler.trackCatched(ex);
     }
 
     /**
      * track exception info that user can provide.
-     * @param name max 255 characters
+     *
+     * @param name    max 255 characters
      * @param message max 255 characters
      */
     public void trackException(String name, String message) {
@@ -458,8 +462,9 @@ public class Webtrekk implements ActivityListener.Callback {
 
     /**
      * this function is be called automatically by activity flow listener
+     *
      * @hide
-     * */
+     */
     @Override
     public void onStart(boolean isRecreationInProcess, ActivityTrackingStatus.STATUS status,
                         long inactivityTime, String activityName) {
@@ -474,15 +479,15 @@ public class Webtrekk implements ActivityListener.Callback {
             mRequestFactory.setCurrentActivityName(activityName);
         }
 
-        if(status == ActivityTrackingStatus.STATUS.FIRST_ACTIVITY_STARTED) {
+        if (status == ActivityTrackingStatus.STATUS.FIRST_ACTIVITY_STARTED) {
             onFirstActivityStart();
         }
 
         // track only if it isn't in background and session timeout isn't passed
-        if (status == ActivityTrackingStatus.STATUS.RETURNINIG_FROM_BACKGROUND){
+        if (status == ActivityTrackingStatus.STATUS.RETURNINIG_FROM_BACKGROUND) {
             if (inactivityTime > trackingConfiguration.getResendOnStartEventTime())
                 mRequestFactory.forceNewSession();
-             mRequestFactory.restore();
+            mRequestFactory.restore();
         }
 
         autoTrackActivity();
@@ -491,7 +496,8 @@ public class Webtrekk implements ActivityListener.Callback {
     /**
      * this method gets called when the first activity of the application has started
      * it loads the old requests from the backupfile and tries to send them
-     *@hide
+     *
+     * @hide
      */
     private void onFirstActivityStart() {
         mRequestFactory.onFirstStart();
@@ -501,6 +507,7 @@ public class Webtrekk implements ActivityListener.Callback {
     /**
      * this function is be called automatically by activity flow listener
      * open activities and knows when to exit
+     *
      * @hide
      */
     @Override
@@ -509,8 +516,7 @@ public class Webtrekk implements ActivityListener.Callback {
             throw new IllegalStateException("webtrekk has not been initialized");
         }
 
-        switch (status)
-        {
+        switch (status) {
             case SHUT_DOWNING:
                 stop();
                 break;
@@ -521,14 +527,12 @@ public class Webtrekk implements ActivityListener.Callback {
     }
 
     /**
-     * @hide
-     * Is called when activity is destroyed to double check that queries are saved and threads are stopped
+     * @hide Is called when activity is destroyed to double check that queries are saved and threads are stopped
      * as in some cases stop isn't called during application showt down.
      */
     @Override
-    public void onDestroy(ActivityTrackingStatus.STATUS status)
-    {
-        if(status == ActivityTrackingStatus.STATUS.SHUT_DOWNING) {
+    public void onDestroy(ActivityTrackingStatus.STATUS status) {
+        if (status == ActivityTrackingStatus.STATUS.SHUT_DOWNING) {
             stop();
         }
     }
@@ -536,6 +540,7 @@ public class Webtrekk implements ActivityListener.Callback {
     /**
      * this method gets called when application is going to be closed
      * it stores all requests to file and stop threads.
+     *
      * @hide
      */
     void stop() {
@@ -554,8 +559,7 @@ public class Webtrekk implements ActivityListener.Callback {
         this.mContext = context;
     }
 
-    RequestFactory getRequestFactory()
-    {
+    RequestFactory getRequestFactory() {
         return mRequestFactory;
     }
 
@@ -568,6 +572,7 @@ public class Webtrekk implements ActivityListener.Callback {
     /**
      * this method is for the opt out switch, when called it will set the shared preferences of opt out
      * and also stops tracking in case the user opts out
+     *
      * @param value boolean value indicating if the user opted out or not
      */
     public void setOptout(boolean value) {
@@ -577,18 +582,18 @@ public class Webtrekk implements ActivityListener.Callback {
     /**
      * Set url for tracking for each activity. This value is reset for each new activity
      * Value is override PAGE_URL parameter in activity configuration if any.
+     *
      * @param url
      * @return
      */
 
-    public boolean setPageURL(String url)
-    {
+    public boolean setPageURL(String url) {
         ActivityConfiguration acConf = trackingConfiguration.getActivityConfigurations().get(mRequestFactory.getCurrentActivityName());
 
         if (!HelperFunctions.testIsValidURL(url)) {
             WebtrekkLogging.log("setPageURL. Invalid url format");
             return false;
-        }else {
+        } else {
 
             if (acConf != null) {
                 acConf.setOverridenPageURL(url);
@@ -601,8 +606,7 @@ public class Webtrekk implements ActivityListener.Callback {
     }
 
     //reset overrated URLTrack
-    private void resetPageURLTrack()
-    {
+    private void resetPageURLTrack() {
         ActivityConfiguration acConf = trackingConfiguration.getActivityConfigurations().get(mRequestFactory.getCurrentActivityName());
 
         if (acConf != null)
@@ -614,28 +618,29 @@ public class Webtrekk implements ActivityListener.Callback {
      * Each time method returns new instance of recommendation object that is initialized accornding to
      * configuration xml. Using WebtrekkRecommendations object you can have independed several recommendation
      * request.
+     *
      * @return WebtrekkRecommendations object
      */
-    public WebtrekkRecommendations getRecommendations()
-    {
+    public WebtrekkRecommendations getRecommendations() {
         return new WebtrekkRecommendations(trackingConfiguration, mContext);
     }
 
 
-    public ProductListTracker getProductListTracker(){
+    public ProductListTracker getProductListTracker() {
         return mProductListTracker;
     }
 
     /**
      * Send manual tracks to server from tracks queue. Is done in separate thread and can be called from UI thread.
      * It must be called when <sendDelay> is zero, otherwise no message is sent to server.
+     *
      * @return true if sending is called and false if previous send procedure hasn't called or nothing to send
-     *              or manual send mode is off (<sendDelay> not zero).
+     * or manual send mode is off (<sendDelay> not zero).
      */
     public boolean send() {
         if (mRequestFactory.getTrackingConfiguration().getSendDelay() == 0) {
             return mRequestFactory.onSendIntervalOver();
-        }else {
+        } else {
             WebtrekkLogging.log("Custom url send mode isn't switched on. Send isn't available. For custom send mode set <sendDelay> to zero ");
             return false;
         }
@@ -643,6 +648,7 @@ public class Webtrekk implements ActivityListener.Callback {
 
     /**
      * allows to set global tracking parameter which will be added to all requests
+     *
      * @return
      */
     public TrackingParameter getGlobalTrackingParameter() {
@@ -672,14 +678,14 @@ public class Webtrekk implements ActivityListener.Callback {
 
     /**
      * this method alles the customer to set the custom parameters map
-     *
      */
     public void setCustomParameter(Map<String, String> customParameter) {
         mRequestFactory.setCustomParameter(customParameter);
     }
 
     /**
-     *Returns current EverId. EverId is generated automatically by SDK, but you can set is manual as well.
+     * Returns current EverId. EverId is generated automatically by SDK, but you can set is manual as well.
+     *
      * @return current EverId
      */
     public String getEverId() {
@@ -689,31 +695,30 @@ public class Webtrekk implements ActivityListener.Callback {
     /**
      * Returns Tracking ID list defined in configuration xml. In most cased it is one item,
      * but theoretically it can be list divided by commas. null if Webtrekk is not initialized.
+     *
      * @return current Tracking ID
      */
     public List<String> getTrackingIDs() {
-        if (trackingConfiguration == null){
+        if (trackingConfiguration == null) {
             WebtrekkLogging.log("webtrekk has not been initialized");
             return null;
-        }else {
+        } else {
             return Arrays.asList(trackingConfiguration.getTrackId().split(","));
         }
     }
 
     /**
      * set EverId. This ever ID will be used for all tracking request until application reinstall.
+     *
      * @param everId - 19 digits string value
      */
-    public void setEverId(String everId)
-    {
-        if (mContext == null)
-        {
+    public void setEverId(String everId) {
+        if (mContext == null) {
             WebtrekkLogging.log("Can't set ever id. Please initialize SDK first.");
             return;
         }
 
-        if (!everId.matches("\\d{19}"))
-        {
+        if (!everId.matches("\\d{19}")) {
             WebtrekkLogging.log("Incorrect everID should have 19 digits");
             return;
         }
@@ -724,12 +729,11 @@ public class Webtrekk implements ActivityListener.Callback {
 
     /**
      * Set deeplink attribution media code. This media code will be sent once with the next tracking request
+     *
      * @param mediaCode - media code
      */
-    public void setMediaCode(String mediaCode)
-    {
-        if (mContext == null)
-        {
+    public void setMediaCode(String mediaCode) {
+        if (mContext == null) {
             WebtrekkLogging.log("Can't set media code. Please initialize SDK first.");
             return;
         }
@@ -739,15 +743,15 @@ public class Webtrekk implements ActivityListener.Callback {
 
     //class for webVeiwCallback
 
-    static class AndroidWebViewCallback{
+    static class AndroidWebViewCallback {
         private final Context mContext;
 
-        AndroidWebViewCallback(@Nullable Context context){
+        AndroidWebViewCallback(@Nullable Context context) {
             mContext = context;
         }
 
         @JavascriptInterface
-        public String getEverId(){
+        public String getEverId() {
             return HelperFunctions.getEverId(mContext);
         }
     }
@@ -760,23 +764,24 @@ public class Webtrekk implements ActivityListener.Callback {
      *
      * @param webView - webView instance can't be null
      */
-    public void setupWebView(WebView webView){
-        if (mContext == null){
+    public void setupWebView(WebView webView) {
+        if (mContext == null) {
             WebtrekkLogging.log("Can't setup WebView. Please initialize SDK first.");
             return;
         }
 
-        if (webView == null){
+        if (webView == null) {
             WebtrekkLogging.log("Can't setup WebView. WebView parameter is null.");
             return;
         }
 
-        if (Looper.getMainLooper().getThread() != Thread.currentThread()){
+        if (Looper.getMainLooper().getThread() != Thread.currentThread()) {
             WebtrekkLogging.log("Can't setup WebView. Function should be called from UI thread.");
             return;
         }
 
-        final String everId = HelperFunctions.getEverId(mContext);;
+        final String everId = HelperFunctions.getEverId(mContext);
+        ;
 
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
             webView.addJavascriptInterface(new AndroidWebViewCallback(mContext), "WebtrekkAndroidWebViewCallback");
@@ -786,16 +791,16 @@ public class Webtrekk implements ActivityListener.Callback {
     }
 
     /**
-     * @hide
      * @return
+     * @hide
      */
     public TrackingConfiguration getTrackingConfiguration() {
         return trackingConfiguration;
     }
 
     /**
-     * @hide
      * @param trackingConfiguration
+     * @hide
      */
     public void setTrackingConfiguration(TrackingConfiguration trackingConfiguration) {
         this.trackingConfiguration = trackingConfiguration;
@@ -803,35 +808,66 @@ public class Webtrekk implements ActivityListener.Callback {
     }
 
     /**
-     * @hide
      * @param context
+     * @hide
      */
-    private void initVersions(Context context)
-    {
+    private void initVersions(Context context) {
         mTrackingLibraryVersionUI = context.getResources().getString(R.string.version_name);
-        mTrackingLibraryVersion = mTrackingLibraryVersionUI.replaceAll("\\D","");
+        mTrackingLibraryVersion = mTrackingLibraryVersionUI.replaceAll("\\D", "");
     }
 
     /**
      * for unit testing in the application and debugging
      */
-    public int getVersion() { return trackingConfiguration.getVersion(); }
-    public String getTrackDomain() { return trackingConfiguration.getTrackDomain(); }
-    public int getSampling() { return trackingConfiguration.getSampling(); }
-    public void setIsSampling(boolean isSampling ) { mRequestFactory.setIsSampling(isSampling); }
-    public int getSendDelay() { return trackingConfiguration.getSendDelay(); }
-    public int getResendOnStartEventTime() { return trackingConfiguration.getResendOnStartEventTime(); }
-    public int getMaxRequests() { return trackingConfiguration.getMaxRequests(); }
-    public String getTrackingConfigurationUrl() { return trackingConfiguration.getTrackingConfigurationUrl(); }
-    public boolean isAutoTracked() { return trackingConfiguration.isAutoTracked(); }
-    public boolean isAutoTrackApiLevel() { return trackingConfiguration.isAutoTrackApiLevel(); }
-    public boolean isEnableRemoteConfiguration() { return trackingConfiguration.isEnableRemoteConfiguration(); }
+    public int getVersion() {
+        return trackingConfiguration.getVersion();
+    }
+
+    public String getTrackDomain() {
+        return trackingConfiguration.getTrackDomain();
+    }
+
+    public int getSampling() {
+        return trackingConfiguration.getSampling();
+    }
+
+    public void setIsSampling(boolean isSampling) {
+        mRequestFactory.setIsSampling(isSampling);
+    }
+
+    public int getSendDelay() {
+        return trackingConfiguration.getSendDelay();
+    }
+
+    public int getResendOnStartEventTime() {
+        return trackingConfiguration.getResendOnStartEventTime();
+    }
+
+    public int getMaxRequests() {
+        return trackingConfiguration.getMaxRequests();
+    }
+
+    public String getTrackingConfigurationUrl() {
+        return trackingConfiguration.getTrackingConfigurationUrl();
+    }
+
+    public boolean isAutoTracked() {
+        return trackingConfiguration.isAutoTracked();
+    }
+
+    public boolean isAutoTrackApiLevel() {
+        return trackingConfiguration.isAutoTrackApiLevel();
+    }
+
+    public boolean isEnableRemoteConfiguration() {
+        return trackingConfiguration.isEnableRemoteConfiguration();
+    }
 
     /**
-     * @deprecated use {@link #getTrackingIDs()} instead
      * @return
+     * @deprecated use {@link #getTrackingIDs()} instead
      */
-    public String getTrackId(){
+    public String getTrackId() {
         return getTrackingIDs().get(0);
     }
 }


### PR DESCRIPTION
**Note: This is a minimum implementation to support our project**
Probably more work needs to be done to make this more 'SDK open source ready'.

New changes:

- `PinConnectionValidator.java` responsible for validating the pinning (requires an optional set of pins - pinning will be ignored when no pins are provided) - Works only for Android API 17 and higher.
- `RequestProcessor.java` now calls `PinConnectionValidator#validatePinning(connection)` when making a request
- Public pins (SHA-256) can be provided via Webtrekk instance initialisation (for the quick implementation to support)

Missing ideal implementations:

- `PinConnectionValidator.java` makes use of `X509TrustManagerExtensions`. This is only available for `Android API 17` and higher. Lower than `API 17` will not be able to pin the public key and will throw an exception. But can be implemented. Our project supports `API 19` and higher, so this implementation is acceptable for us. However, Webtrekk API wise there is nothing breaking if you don't provide pins. So we can say, you can only use pinning on this SDK is only working for API 17 and higher, unless the lower versions support is implemented for the `TrustChecker` interface.
- No unit/integration tests (now it's manually tested, via different scenarios)
- No XML configuration support yet for the public keys. The Webtrekk XML parser is not supporting arrays yet, so we implemented the quick fix by passing the set of pins via the `Webtrekk#initWebtrekk`

I have also heard that Webtrekk will work on pinning support in Q3 on the roadmap. So this pull request can be an input for the implementation that fits the Webtrekk vision.