### PR TITLE
Add an option to enable TLSv1.2 on some Android versions.

### DIFF
--- a/webtrekk_sdk/src/main/java/com/webtrekk/webtrekksdk/Request/RequestProcessor.java
+++ b/webtrekk_sdk/src/main/java/com/webtrekk/webtrekksdk/Request/RequestProcessor.java
@@ -19,6 +19,7 @@
 package com.webtrekk.webtrekksdk.Request;
 
 import com.webtrekk.webtrekksdk.Utils.PinConnectionValidator;
+import com.webtrekk.webtrekksdk.Utils.Tls12SocketFactory;
 import com.webtrekk.webtrekksdk.Utils.WebtrekkLogging;
 
 import java.io.EOFException;
@@ -29,6 +30,10 @@ import java.net.URL;
 import java.net.UnknownHostException;
 
 import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+
+import static com.webtrekk.webtrekksdk.Utils.HelperFunctions.*;
+import static com.webtrekk.webtrekksdk.Webtrekk.isTls12Enabled;
 
 /**
  * this class sends the requests to the server
@@ -76,7 +81,21 @@ public class RequestProcessor implements Runnable {
      */
 
     public HttpsURLConnection getUrlConnection(URL url) throws IOException {
-        return (HttpsURLConnection) url.openConnection();
+
+        final HttpsURLConnection urlConnection = (HttpsURLConnection) url.openConnection();
+
+        if(isTls12Enabled() && isTls12Supported()) {
+            try {
+                SSLContext sc = SSLContext.getInstance("TLSv1.2");
+                sc.init(null, null, null);
+                urlConnection.setSSLSocketFactory(new Tls12SocketFactory(sc.getSocketFactory()));
+            }
+            catch (Exception e) {
+                WebtrekkLogging.log("RequestProcessor: No TLSv1.2 support.", e);
+            }
+        }
+
+        return urlConnection;
     }
 
     /**

--- a/webtrekk_sdk/src/main/java/com/webtrekk/webtrekksdk/Utils/HelperFunctions.java
+++ b/webtrekk_sdk/src/main/java/com/webtrekk/webtrekksdk/Utils/HelperFunctions.java
@@ -576,6 +576,14 @@ final public class HelperFunctions {
         return builder.toString();
     }
 
+    // Devices from API level 16 (Jelly Bean) on support TLSv1.2, but it's not enabled per default
+    // see https://developer.android.com/reference/javax/net/ssl/SSLContext
+    public static boolean isTls12Supported() {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN &&
+                Build.VERSION.SDK_INT <= Build.VERSION_CODES.LOLLIPOP;
+
+    }
+
     public String getXmlFromUrl(String url) throws IOException {
         String xml = null;
         // defaultHttpClient

--- a/webtrekk_sdk/src/main/java/com/webtrekk/webtrekksdk/Utils/Tls12SocketFactory.java
+++ b/webtrekk_sdk/src/main/java/com/webtrekk/webtrekksdk/Utils/Tls12SocketFactory.java
@@ -1,0 +1,68 @@
+package com.webtrekk.webtrekksdk.Utils;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+
+/**
+ * Enables TLS v1.2 when creating SSLSockets.
+ * <p>
+ * For some reason, android supports TLS v1.2 from API 16, but enables it by
+ * default only from API 20.
+ * @link https://developer.android.com/reference/javax/net/ssl/SSLSocket.html
+ * @see SSLSocketFactory
+ */
+public class Tls12SocketFactory extends SSLSocketFactory {
+    private static final String[] TLS_V12_ONLY = {"TLSv1.2"};
+
+    private final SSLSocketFactory delegate;
+
+    public Tls12SocketFactory(SSLSocketFactory base) {
+        this.delegate = base;
+    }
+
+    @Override
+    public String[] getDefaultCipherSuites() {
+        return delegate.getDefaultCipherSuites();
+    }
+
+    @Override
+    public String[] getSupportedCipherSuites() {
+        return delegate.getSupportedCipherSuites();
+    }
+
+    @Override
+    public Socket createSocket(Socket s, String host, int port, boolean autoClose) throws IOException {
+        return patch(delegate.createSocket(s, host, port, autoClose));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port) throws IOException {
+        return patch(delegate.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws IOException {
+        return patch(delegate.createSocket(host, port, localHost, localPort));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress host, int port) throws IOException {
+        return patch(delegate.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort) throws IOException {
+        return patch(delegate.createSocket(address, port, localAddress, localPort));
+    }
+
+    private Socket patch(Socket s) {
+        if (s instanceof SSLSocket) {
+            ((SSLSocket) s).setEnabledProtocols(TLS_V12_ONLY);
+        }
+        return s;
+    }
+}

--- a/webtrekk_sdk/src/main/java/com/webtrekk/webtrekksdk/Webtrekk.java
+++ b/webtrekk_sdk/src/main/java/com/webtrekk/webtrekksdk/Webtrekk.java
@@ -73,12 +73,12 @@ public class Webtrekk implements ActivityListener.Callback {
     private ProductListTracker mProductListTracker;
     private boolean mIsInitialized;
 
+    private static boolean tls12Enabled;
 
     /**
      * non public constructor to create a Webtrekk Instance as
      * makes use of the Singleton Pattern here.
      */
-
     Webtrekk() {
     }
 
@@ -325,6 +325,14 @@ public class Webtrekk implements ActivityListener.Callback {
      */
     public static void setLoggingEnabled(boolean logging) {
         WebtrekkLogging.setIsLogging(logging);
+    }
+
+    public static boolean isTls12Enabled() {
+        return tls12Enabled;
+    }
+
+    public static void setTls12Enabled(boolean tls12Enabled) {
+        Webtrekk.tls12Enabled = tls12Enabled;
     }
 
     public boolean isSampling() {


### PR DESCRIPTION
Add an option to enable TLSv1.2 on some Android versions. 

Devices have to support TLSv1.2 from API level 16 (Jelly Bean) on,
but it's not enabled per default till API level 21 (Lollipop) [1,2].

To use this option on such devices, add the following line before
initialization of class "Webtrekk":

  Webtrekk.setTls12Enabled(true);
  Webtrekk.getInstance().initWebtrekk(..);

[1] https://developer.android.com/reference/javax/net/ssl/SSLContext
[2] square/okhttp#2372